### PR TITLE
Quick fix of periodic mesh example [per-mesh-dev]

### DIFF
--- a/src/mesh-format-v1.x.md
+++ b/src/mesh-format-v1.x.md
@@ -97,7 +97,7 @@ boundary
 3 1 9 16
 
 vertices
-16
+18
 
 # END Topology Part
 ...
@@ -869,7 +869,7 @@ boundary
 3 1 9 16
 
 vertices
-16
+18
 
 nodes
 FiniteElementSpace


### PR DESCRIPTION
As pointed out in MFEM issue [#1519](https://github.com/mfem/mfem/issues/1519) the periodic example mesh does not run in the current version of example 1.  The cause is that the mesh file has node index 16 but specifies a total of 16 nodes.  Consequently, MFEM expects the nodes to be numbered from 0 to 15 and index 16 looks beyond the end of the `v2v` array in `Mesh::RemoveUnusedVertices`.

There are at least three possible fixes:
1) Require meshes to use contiguous node numbers.
2) Modify `Mesh::RemoveUnusedVertices`, and possibly other methods, to search for the highest node index rather than assume it's going to be `Mesh:GetNV()-1`.
3) Modify the mesh file so that the number of vertices is larger than the highest index appearing in the file.

In this PR I chose option 3 because it is the least invasive. 