### PR TITLE
Improved example filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Checklist for adding examples:
 - Add a one-line summary of the example in `features.md`
 - Add an image file in `img/examples/`, e.g. `img/examples/ex1.png`
 - Add a brief description in `examples.md` following the description at the top of the C++ file
-- Update `numExamples` in examples.md in the JavaScript code at the end of the files
+- Add a line with the appropriate  categories for the example in the `update` function at the end of `examples.md`
 
 To add a new Application / Finite Elements / Discretization / Solver category:
 
 - Add a radio button at the top of `examples.md`, e.g.
   ```<label><input type="radio" id="wave" onchange="update(this.id);" /> Wave</label><br/>```
-- List the `id` in the appropriate examples in `update` at the end of `examples.md`, e.g.
+- Add the `id` to the appropriate group at the beginning of the `update` function at the end of `examples.md`.
+- Use the `id` in filter expressions of appropriate examples in `update`, e.g.
   ```showElement("ex25", (maxwell || wave) && hcurl && galerkin && (gmres || ams));```
 
 Checklist for adding miniapps:
@@ -32,8 +33,7 @@ Checklist for adding miniapps:
 - Consider adding a one-line summary of the example in `features.md` (if we want to advertise the miniapp to users)
 - Add an image file in `img/examples/`, e.g. `img/examples/shaper.png`
 - Add a brief description in `examples.md` following the description at the top of the C++ file
-- Update `numExamples` and `miniappList` in examples.md in the JavaScript code at the end of the files in the appropriate miniapps section
-- Add a line with the appropriate  categories for the example in the `update` function at the end of `examples.md`
+- Add a line with the appropriate  categories for the miniapp in the `update` function at the end of `examples.md`
 - If the miniapp is part of a group, e.g. meshing miniapps, add it also to `meshing.md`
 
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ Checklist for adding examples:
 - Add a one-line summary of the example in `features.md`
 - Add an image file in `img/examples/`, e.g. `img/examples/ex1.png`
 - Add a brief description in `examples.md` following the description at the top of the C++ file
-- Add a line with the appropriate  categories for the example in the `update` function at the end of `examples.md`
+- Add a "showElement" line with the appropriate categories for the example in the `update` function at the end of `examples.md`
 
 To add a new Application / Finite Elements / Discretization / Solver category:
 
-- Add a radio button at the top of `examples.md`, e.g.
-  ```<label><input type="radio" id="wave" onchange="update(this.id);" /> Wave</label><br/>```
-- Add the `id` to the appropriate group at the beginning of the `update` function at the end of `examples.md`.
+- Add an `<option>` tag at the top of `examples.md`, e.g.
+  ```<option id="wave">Wave</option>```
 - Use the `id` in filter expressions of appropriate examples in `update`, e.g.
   ```showElement("ex25", (maxwell || wave) && hcurl && galerkin && (gmres || ams));```
 
@@ -33,7 +32,7 @@ Checklist for adding miniapps:
 - Consider adding a one-line summary of the example in `features.md` (if we want to advertise the miniapp to users)
 - Add an image file in `img/examples/`, e.g. `img/examples/shaper.png`
 - Add a brief description in `examples.md` following the description at the top of the C++ file
-- Add a line with the appropriate  categories for the miniapp in the `update` function at the end of `examples.md`
+- Add a "showElement" line with the appropriate categories for the miniapp in the `update` function at the end of `examples.md`
 - If the miniapp is part of a group, e.g. meshing miniapps, add it also to `meshing.md`
 
 

--- a/src/examples.md
+++ b/src/examples.md
@@ -18,8 +18,8 @@ more representative of the advanced usage of the library in physics/application
 codes. We recommend that new users start with the example codes before moving to
 the miniapps.
 
-Clicking on any of the categories below displays examples and miniapps that contain the
-described feature. _All examples support (arbitrarily) high-order meshes and
+Select from the categories below to displays examples and miniapps that contain the
+respective feature. _All examples support (arbitrarily) high-order meshes and
 finite element spaces_.
 The numerical results from the example codes can be visualized using the
 GLVis visualization tool (based on MFEM). See the
@@ -34,66 +34,75 @@ or post [questions](https://github.com/mfem/mfem/issues/new?labels=question) or 
 <div class="row" markdown="1">
 <div class="col-sm-6 col-md-2 small" markdown="1">
    <h5>**Application (PDE)**</h5>
-   <label><input type="radio" id="all1" onchange="update(this.id);" checked="checked" /> All</label><br/>
-   <label><input type="radio" id="laplace" onchange="update(this.id);" /> Laplace</label><br/>
-   <label><input type="radio" id="elasticity" onchange="update(this.id);" /> Elasticity</label><br/>
-   <label><input type="radio" id="maxwell" onchange="update(this.id);" /> Electromagnetics</label><br/>
-   <label><input type="radio" id="graddiv" onchange="update(this.id);" /> grad-div</label><br/>
-   <label><input type="radio" id="darcy" onchange="update(this.id);" /> Darcy</label><br/>
-   <label><input type="radio" id="advection" onchange="update(this.id);" /> Advection</label><br/>
-   <label><input type="radio" id="conduction" onchange="update(this.id);" /> Conduction</label><br/>
-   <label><input type="radio" id="wave" onchange="update(this.id);" /> Wave</label><br/>
-   <label><input type="radio" id="hydro" onchange="update(this.id);" /> Hydrodynamics</label><br/>
-   <label><input type="radio" id="meshing" onchange="update(this.id);" /> Meshing</label><br/>
-   <label><input type="radio" id="fluid" onchange="update(this.id);" /> Fluid</label><br/>
+   <select id="group1" onchange="update()">
+      <option value="all1">All</option>
+      <option value="laplace">Laplace</option>
+      <option value="elasticity">Elasticity</option>
+      <option value="maxwell">Electromagnetics</option>
+      <option value="graddiv">grad-div</option>
+      <option value="darcy">Darcy</option>
+      <option value="advection">Advection</option>
+      <option value="conduction">Conduction</option>
+      <option value="wave">Wave</option>
+      <option value="hydro">Hydrodynamics</option>
+      <option value="meshing">Meshing</option>
+      <option value="fluid">Fluid</option>
+   </select>
 </div>
 <div class="col-sm-6 col-md-3 small" markdown="1">
    <h5>**Finite Elements**</h5>
-   <label><input type="radio" id="all2" onchange="update(this.id);" checked="checked" /> All</label><br/>
-   <label><input type="radio" id="l2" onchange="update(this.id);" /> $L_2$ discontinuous elements</label><br/>
-   <label><input type="radio" id="h1" onchange="update(this.id);" /> $H^1$ nodal elements</label><br/>
-   <label><input type="radio" id="hcurl" onchange="update(this.id);" /> $H(curl)$ Nedelec elements</label><br/>
-   <label><input type="radio" id="hdiv" onchange="update(this.id);" /> $H(div)$ Raviart-Thomas elements</label><br/>
-   <label><input type="radio" id="h12" onchange="update(this.id);" /> $H^{-1/2}$ interfacial elements</label><br/>
+   <select id="group2" onchange="update()">
+      <option value="all2">All</option>
+      <option value="l2">L2 discontinuous elements</option>
+      <option value="h1">H1 nodal elements</option>
+      <option value="hcurl">H(curl) Nedelec elements</option>
+      <option value="hdiv">H(div) Raviart-Thomas elements</option>
+      <option value="h12">H^{-1/2} interfacial elements</option>
+   </select>
 </div>
 <div class="clearfix hidden-md hidden-lg"></div>
 <div class="col-sm-6 col-md-3 small" markdown="1">
    <h5>**Discretization**</h5>
-   <label><input type="radio" id="all3" onchange="update(this.id);" checked="checked" /> All</label><br/>
-   <label><input type="radio" id="galerkin" onchange="update(this.id);" /> Galerkin FEM</label><br/>
-   <label><input type="radio" id="mixed" onchange="update(this.id);" /> Mixed FEM</label><br/>
-   <label><input type="radio" id="dg" onchange="update(this.id);" /> Discontinuous Galerkin (DG)</label><br/>
-   <label><input type="radio" id="dpg" onchange="update(this.id);" /> Discont. Petrov-Galerkin (DPG)</label><br/>
-   <label><input type="radio" id="hybr" onchange="update(this.id);" /> Hybridization</label><br/>
-   <label><input type="radio" id="staticcond" onchange="update(this.id);" /> Static condensation</label><br/>
-   <label><input type="radio" id="nurbs" onchange="update(this.id);" /> Isogeometric analysis (NURBS)</label><br/>
-   <label><input type="radio" id="amr" onchange="update(this.id);" /> Adaptive mesh refinement (AMR)</label><br/>
-   <label><input type="radio" id="pa" onchange="update(this.id);" /> Partial assembly</label><br/>
+   <select id="group3" onchange="update()">
+      <option value="all3">All</option>
+      <option value="galerkin">Galerkin FEM</option>
+      <option value="mixed">Mixed FEM</option>
+      <option value="dg">Discontinuous Galerkin (DG)</option>
+      <option value="dpg">Discont. Petrov-Galerkin (DPG)</option>
+      <option value="hybr">Hybridization</option>
+      <option value="staticcond">Static condensation</option>
+      <option value="nurbs">Isogeometric analysis (NURBS)</option>
+      <option value="amr">Adaptive mesh refinement (AMR)</option>
+      <option value="pa">Partial assembly</option>
+   </select>
 </div>
 <div class="col-sm-6 col-md-4 small" markdown="1">
    <h5>**Solver**</h5>
-   <label><input type="radio" id="all4" onchange="update(this.id);" checked="checked" /> All</label><br/>
-   <label><input type="radio" id="jacobi" onchange="update(this.id);" /> Jacobi</label> <br/>
-   <label><input type="radio" id="gs" onchange="update(this.id);" /> Gauss-Seidel</label> <br/>
-   <label><input type="radio" id="pcg" onchange="update(this.id);" /> PCG</label> <br/>
-   <label><input type="radio" id="minres" onchange="update(this.id);" /> MINRES</label> <br/>
-   <label><input type="radio" id="gmres" onchange="update(this.id);" /> GMRES</label> <br/>
-   <label><input type="radio" id="amg" onchange="update(this.id);" /> Algebraic Multigrid (BoomerAMG)</label> <br/>
-   <label><input type="radio" id="ams" onchange="update(this.id);" /> Auxiliary-space Maxwell Solver (AMS)</label> <br/>
-   <label><input type="radio" id="ads" onchange="update(this.id);" /> Auxiliary-space Divergence Solver (ADS)</label> <br/>
-   <label><input type="radio" id="superlu" onchange="update(this.id);" /> SuperLU/STRUMPACK (parallel direct)</label><br/>
-   <label><input type="radio" id="umfpack" onchange="update(this.id);" /> UMFPACK (serial direct)</label><br/>
-   <label><input type="radio" id="newton" onchange="update(this.id);" /> Newton method (nonlinear solver)</label><br/>
-   <label><input type="radio" id="rk" onchange="update(this.id);" /> Explicit Runge-Kutta (ODE integration)</label><br/>
-   <label><input type="radio" id="sdirk" onchange="update(this.id);" /> Implicit Runge-Kutta (ODE integration)</label><br/>
-   <label><input type="radio" id="newmark" onchange="update(this.id);" /> Newmark (ODE Integration)</label><br/>
-   <label><input type="radio" id="symplectic" onchange="update(this.id);" /> Symplectic Algorithm (ODE Integration)</label><br/>
-   <label><input type="radio" id="lobpcg" onchange="update(this.id);" /> LOBPCG, AME (eigensolvers)</label><br/>
-   <label><input type="radio" id="sundials" onchange="update(this.id);" /> SUNDIALS solvers</label><br/>
-   <label><input type="radio" id="petsc" onchange="update(this.id);" /> PETSc solvers</label><br/>
-   <label><input type="radio" id="hiop" onchange="update(this.id);" /> HiOp solvers</label><br/>
+   <select id="group4" onchange="update()">
+      <option value="all4">All</option>
+      <option value="jacobi">Jacobi</option>
+      <option value="gs">Gauss-Seidel</option>
+      <option value="pcg">PCG</option>
+      <option value="minres">MINRES</option>
+      <option value="gmres">GMRES</option>
+      <option value="amg">Algebraic Multigrid (BoomerAMG)</option>
+      <option value="ams">Auxiliary-space Maxwell Solver (AMS)</option>
+      <option value="ads">Auxiliary-space Divergence Solver (ADS)</option>
+      <option value="superlu">SuperLU/STRUMPACK (parallel direct)</option>
+      <option value="umfpack">UMFPACK (serial direct)</option>
+      <option value="newton">Newton method (nonlinear solver)</option>
+      <option value="rk">Explicit Runge-Kutta (ODE integration)</option>
+      <option value="sdirk">Implicit Runge-Kutta (ODE integration)</option>
+      <option value="newmark">Newmark (ODE Integration)</option>
+      <option value="symplectic">Symplectic Algorithm (ODE Integration)</option>
+      <option value="lobpcg">LOBPCG, AME (eigensolvers)</option>
+      <option value="sundials">SUNDIALS solvers</option>
+      <option value="petsc">PETSc solvers</option>
+      <option value="hiop">HiOp solvers</option>
+   </select>
 </div>
 </div>
+<br>
 <hr>
 
 <!-- ------------------------------------------------------------------------- -->
@@ -1386,17 +1395,26 @@ function updateGroup(names, id)
       this[names[i]] = isChecked(names[i]) || isChecked(names[0]/*all*/);
 }
 
-function update(id)
+function getBooleans(names, comboId)
+{
+    selected = document.getElementById(comboId).value
+    // generate boolean variables from the group names
+    for (i = 0; i < names.length; ++i) {
+       this[names[i]] = (names[i] == selected) || (names[0] /*all*/ == selected);
+    }
+}
+
+function update()
 {
    var group1 = ["all1", "laplace", "elasticity", "maxwell", "graddiv", "darcy", "advection", "conduction", "wave", "hydro", "meshing", "fluid"];
    var group2 = ["all2", "l2", "h1", "hcurl", "hdiv", "h12"];
    var group3 = ["all3", "galerkin", "mixed", "dg", "dpg", "hybr", "staticcond", "nurbs", "amr", "pa" ];
    var group4 = ["all4", "jacobi", "gs", "pcg", "minres", "gmres", "amg", "ams", "ads", "superlu", "umfpack", "newton", "rk", "sdirk", "newmark", "symplectic", "lobpcg", "sundials", "petsc", "hiop"];
 
-   updateGroup(group1, id);
-   updateGroup(group2, id);
-   updateGroup(group3, id);
-   updateGroup(group4, id);
+   getBooleans(group1, "group1");
+   getBooleans(group2, "group2");
+   getBooleans(group3, "group3");
+   getBooleans(group4, "group4");
 
    numShown = 0 // expression continued...
 

--- a/src/examples.md
+++ b/src/examples.md
@@ -18,7 +18,7 @@ more representative of the advanced usage of the library in physics/application
 codes. We recommend that new users start with the example codes before moving to
 the miniapps.
 
-Select from the categories below to displays examples and miniapps that contain the
+Select from the categories below to display examples and miniapps that contain the
 respective feature. _All examples support (arbitrarily) high-order meshes and
 finite element spaces_.
 The numerical results from the example codes can be visualized using the

--- a/src/examples.md
+++ b/src/examples.md
@@ -1406,6 +1406,7 @@ function getBooleans(names, comboId)
 
 function update()
 {
+   // TODO: pull the names directly from the combos
    var group1 = ["all1", "laplace", "elasticity", "maxwell", "graddiv", "darcy", "advection", "conduction", "wave", "hydro", "meshing", "fluid"];
    var group2 = ["all2", "l2", "h1", "hcurl", "hdiv", "h12"];
    var group3 = ["all3", "galerkin", "mixed", "dg", "dpg", "hybr", "staticcond", "nurbs", "amr", "pa" ];

--- a/src/examples.md
+++ b/src/examples.md
@@ -35,70 +35,70 @@ or post [questions](https://github.com/mfem/mfem/issues/new?labels=question) or 
 <div class="col-sm-6 col-md-2 small" markdown="1">
    <h5>**Application (PDE)**</h5>
    <select id="group1" onchange="update()">
-      <option value="all1">All</option>
-      <option value="laplace">Laplace</option>
-      <option value="elasticity">Elasticity</option>
-      <option value="maxwell">Electromagnetics</option>
-      <option value="graddiv">grad-div</option>
-      <option value="darcy">Darcy</option>
-      <option value="advection">Advection</option>
-      <option value="conduction">Conduction</option>
-      <option value="wave">Wave</option>
-      <option value="hydro">Hydrodynamics</option>
-      <option value="meshing">Meshing</option>
-      <option value="fluid">Fluid</option>
+      <option id="all1">All</option>
+      <option id="laplace">Laplace</option>
+      <option id="elasticity">Elasticity</option>
+      <option id="maxwell">Electromagnetics</option>
+      <option id="graddiv">grad-div</option>
+      <option id="darcy">Darcy</option>
+      <option id="advection">Advection</option>
+      <option id="conduction">Conduction</option>
+      <option id="wave">Wave</option>
+      <option id="hydro">Hydrodynamics</option>
+      <option id="meshing">Meshing</option>
+      <option id="fluid">Fluid</option>
    </select>
 </div>
 <div class="col-sm-6 col-md-3 small" markdown="1">
    <h5>**Finite Elements**</h5>
    <select id="group2" onchange="update()">
-      <option value="all2">All</option>
-      <option value="l2">L2 discontinuous elements</option>
-      <option value="h1">H1 nodal elements</option>
-      <option value="hcurl">H(curl) Nedelec elements</option>
-      <option value="hdiv">H(div) Raviart-Thomas elements</option>
-      <option value="h12">H^{-1/2} interfacial elements</option>
+      <option id="all2">All</option>
+      <option id="h1">H1 nodal elements</option>
+      <option id="l2">L2 discontinuous elements</option>
+      <option id="hcurl">H(curl) Nedelec elements</option>
+      <option id="hdiv">H(div) Raviart-Thomas elements</option>
+      <option id="h12">H^{-1/2} interfacial elements</option>
    </select>
 </div>
 <div class="clearfix hidden-md hidden-lg"></div>
 <div class="col-sm-6 col-md-3 small" markdown="1">
    <h5>**Discretization**</h5>
    <select id="group3" onchange="update()">
-      <option value="all3">All</option>
-      <option value="galerkin">Galerkin FEM</option>
-      <option value="mixed">Mixed FEM</option>
-      <option value="dg">Discontinuous Galerkin (DG)</option>
-      <option value="dpg">Discont. Petrov-Galerkin (DPG)</option>
-      <option value="hybr">Hybridization</option>
-      <option value="staticcond">Static condensation</option>
-      <option value="nurbs">Isogeometric analysis (NURBS)</option>
-      <option value="amr">Adaptive mesh refinement (AMR)</option>
-      <option value="pa">Partial assembly</option>
+      <option id="all3">All</option>
+      <option id="galerkin">Galerkin FEM</option>
+      <option id="mixed">Mixed FEM</option>
+      <option id="dg">Discontinuous Galerkin (DG)</option>
+      <option id="dpg">Discont. Petrov-Galerkin (DPG)</option>
+      <option id="hybr">Hybridization</option>
+      <option id="staticcond">Static condensation</option>
+      <option id="nurbs">Isogeometric analysis (NURBS)</option>
+      <option id="amr">Adaptive mesh refinement (AMR)</option>
+      <option id="pa">Partial assembly</option>
    </select>
 </div>
 <div class="col-sm-6 col-md-4 small" markdown="1">
    <h5>**Solver**</h5>
    <select id="group4" onchange="update()">
-      <option value="all4">All</option>
-      <option value="jacobi">Jacobi</option>
-      <option value="gs">Gauss-Seidel</option>
-      <option value="pcg">PCG</option>
-      <option value="minres">MINRES</option>
-      <option value="gmres">GMRES</option>
-      <option value="amg">Algebraic Multigrid (BoomerAMG)</option>
-      <option value="ams">Auxiliary-space Maxwell Solver (AMS)</option>
-      <option value="ads">Auxiliary-space Divergence Solver (ADS)</option>
-      <option value="superlu">SuperLU/STRUMPACK (parallel direct)</option>
-      <option value="umfpack">UMFPACK (serial direct)</option>
-      <option value="newton">Newton method (nonlinear solver)</option>
-      <option value="rk">Explicit Runge-Kutta (ODE integration)</option>
-      <option value="sdirk">Implicit Runge-Kutta (ODE integration)</option>
-      <option value="newmark">Newmark (ODE Integration)</option>
-      <option value="symplectic">Symplectic Algorithm (ODE Integration)</option>
-      <option value="lobpcg">LOBPCG, AME (eigensolvers)</option>
-      <option value="sundials">SUNDIALS solvers</option>
-      <option value="petsc">PETSc solvers</option>
-      <option value="hiop">HiOp solvers</option>
+      <option id="all4">All</option>
+      <option id="jacobi">Jacobi</option>
+      <option id="gs">Gauss-Seidel</option>
+      <option id="pcg">PCG</option>
+      <option id="minres">MINRES</option>
+      <option id="gmres">GMRES</option>
+      <option id="amg">Algebraic Multigrid (BoomerAMG)</option>
+      <option id="ams">Auxiliary-space Maxwell Solver (AMS)</option>
+      <option id="ads">Auxiliary-space Divergence Solver (ADS)</option>
+      <option id="superlu">SuperLU/STRUMPACK (parallel direct)</option>
+      <option id="umfpack">UMFPACK (serial direct)</option>
+      <option id="newton">Newton method (nonlinear solver)</option>
+      <option id="rk">Explicit Runge-Kutta (ODE integration)</option>
+      <option id="sdirk">Implicit Runge-Kutta (ODE integration)</option>
+      <option id="newmark">Newmark (ODE Integration)</option>
+      <option id="symplectic">Symplectic Algorithm (ODE Integration)</option>
+      <option id="lobpcg">LOBPCG, AME (eigensolvers)</option>
+      <option id="sundials">SUNDIALS solvers</option>
+      <option id="petsc">PETSc solvers</option>
+      <option id="hiop">HiOp solvers</option>
    </select>
 </div>
 </div>
@@ -1360,15 +1360,6 @@ No examples or miniapps match your criteria.
 
 <div style="clear:both;"/></div>
 <script type="text/javascript"><!--
-function isChecked(id)
-{
-    return document.getElementById(id).checked;
-}
-
-function setChecked(id, value)
-{
-    document.getElementById(id).checked = value;
-}
 
 function showElement(id, show)
 {
@@ -1377,45 +1368,36 @@ function showElement(id, show)
     // workaround because Doxygen splits and duplicates the divs for some reason
     var divs = document.getElementsByTagName("div");
     for (i = 0; i < divs.length; i++)
-        if (divs.item(i).id == id)
-            divs.item(i).style.display = show ? "block" : "none";
-
+    {
+       if (divs.item(i).id == id) {
+          divs.item(i).style.display = show ? "block" : "none";
+       }
+    }
     return show ? 1 : 0;
 }
 
-function updateGroup(names, id)
+function getBooleans(comboId)
 {
-   // make only one box checked in the group
-   if (names.indexOf(id) != -1)
-      for (i = 0; i < names.length; ++i)
-         setChecked(names[i], id == names[i]);
+   combo = document.getElementById(comboId);
 
-   // generate boolean variables from the group names
-   for (i = 0; i < names.length; ++i)
-      this[names[i]] = isChecked(names[i]) || isChecked(names[0]/*all*/);
-}
+   first_selected = false;
+   for (i = 0; i < combo.options.length; i++)
+   {
+      opt = combo.options[i];
+      selected = opt.selected || first_selected;
+      if (!i) { first_selected = selected; }
 
-function getBooleans(names, comboId)
-{
-    selected = document.getElementById(comboId).value
-    // generate boolean variables from the group names
-    for (i = 0; i < names.length; ++i) {
-       this[names[i]] = (names[i] == selected) || (names[0] /*all*/ == selected);
-    }
+      // create a boolean variable named after the option
+      this[opt.id] = selected;
+   }
 }
 
 function update()
 {
-   // TODO: pull the names directly from the combos
-   var group1 = ["all1", "laplace", "elasticity", "maxwell", "graddiv", "darcy", "advection", "conduction", "wave", "hydro", "meshing", "fluid"];
-   var group2 = ["all2", "l2", "h1", "hcurl", "hdiv", "h12"];
-   var group3 = ["all3", "galerkin", "mixed", "dg", "dpg", "hybr", "staticcond", "nurbs", "amr", "pa" ];
-   var group4 = ["all4", "jacobi", "gs", "pcg", "minres", "gmres", "amg", "ams", "ads", "superlu", "umfpack", "newton", "rk", "sdirk", "newmark", "symplectic", "lobpcg", "sundials", "petsc", "hiop"];
-
-   getBooleans(group1, "group1");
-   getBooleans(group2, "group2");
-   getBooleans(group3, "group3");
-   getBooleans(group4, "group4");
+   getBooleans("group1");
+   getBooleans("group2");
+   getBooleans("group3");
+   getBooleans("group4");
 
    numShown = 0 // expression continued...
 
@@ -1477,13 +1459,15 @@ function update()
    showElement("nomatch", numShown == 0);
 }
 
-function initButtons()
+function initCombos()
 {
    var query = location.search.substr(1);
    query.split("&").forEach(function(id)
    {
-      setChecked(id, true);
-      update(id);
+      if (id) {
+         opt = document.getElementById(id);
+         if (opt) { opt.selected = true; }
+      }
    });
 }
 
@@ -1494,6 +1478,6 @@ window.onload = update;
 document.getElementsByTagName("body")[0].style = "overflow-y: scroll"
 
 // parse URL part after '?', e.g., http://.../index.html?elasticity&nurbs
-initButtons();
+initCombos();
 
 //--></script>

--- a/src/examples.md
+++ b/src/examples.md
@@ -1370,6 +1370,8 @@ function showElement(id, show)
     for (i = 0; i < divs.length; i++)
         if (divs.item(i).id == id)
             divs.item(i).style.display = show ? "block" : "none";
+
+    return show ? 1 : 0;
 }
 
 function updateGroup(names, id)
@@ -1381,33 +1383,12 @@ function updateGroup(names, id)
 
    // generate boolean variables from the group names
    for (i = 0; i < names.length; ++i)
-      this[names[i]] = isChecked(names[i]) || isChecked(names[0]);
-}
-
-function elementVisible(id)
-{
-   var elem = document.getElementById(id);
-   return elem != null && elem.style.display != "none";
-}
-
-function exampleVisible(num)
-{
-   return elementVisible("ex"+num);// || elementVisible("ex"+num+"p");
-}
-
-function miniappVisible(miniappList)
-{
-   for (i = 0; i < miniappList.length; i++) {
-      if (elementVisible(miniappList[i])) {
-         return true;
-      }
-   }
-   return false;
+      this[names[i]] = isChecked(names[i]) || isChecked(names[0]/*all*/);
 }
 
 function update(id)
 {
-   var group1 = ["all1", "laplace", "elasticity", "maxwell", "graddiv", "darcy", "advection", "conduction","wave", "hydro", "meshing", "fluid"];
+   var group1 = ["all1", "laplace", "elasticity", "maxwell", "graddiv", "darcy", "advection", "conduction", "wave", "hydro", "meshing", "fluid"];
    var group2 = ["all2", "l2", "h1", "hcurl", "hdiv", "h12"];
    var group3 = ["all3", "galerkin", "mixed", "dg", "dpg", "hybr", "staticcond", "nurbs", "amr", "pa" ];
    var group4 = ["all4", "jacobi", "gs", "pcg", "minres", "gmres", "amg", "ams", "ads", "superlu", "umfpack", "newton", "rk", "sdirk", "newmark", "symplectic", "lobpcg", "sundials", "petsc", "hiop"];
@@ -1417,80 +1398,64 @@ function update(id)
    updateGroup(group3, id);
    updateGroup(group4, id);
 
-   // Example codes
-   var numExamples = 26; // update when adding examples!
-   showElement("ex1",  (laplace) && h1 && (galerkin || nurbs || staticcond || pa) && (gs || pcg || umfpack || amg || petsc));
-   showElement("ex2",  elasticity && h1 && (galerkin || nurbs || staticcond) && (gs || pcg || umfpack || amg || petsc));
-   showElement("ex3",  (maxwell) && hcurl && (galerkin || staticcond || pa) && (gs || pcg || umfpack || ams || petsc));
-   showElement("ex4",  graddiv && (hdiv || h12) && (galerkin || hybr || staticcond || pa) && (gs || pcg || umfpack || amg || ads || ams || petsc));
-   showElement("ex5",  darcy && (l2 || hdiv) && (mixed || pa) && (gs || jacobi || minres || umfpack || amg  || petsc));
-   showElement("ex6",  (laplace) && h1 && (galerkin || nurbs || amr || pa) && (gs || pcg || umfpack || amg || petsc));
-   showElement("ex7",  (laplace || meshing) && h1 && (galerkin || amr) && (gs || pcg || umfpack || amg));
-   showElement("ex8",  laplace && (l2 || h1 || h12) && dpg && (gs || pcg || umfpack || amg || ads || ams));
-   showElement("ex9",  (advection) && l2 && (dg || pa) && (pcg || rk || sundials || petsc || hiop || gmres || sdirk));
-   showElement("ex10", elasticity && (l2 || h1) && galerkin && (jacobi || pcg || minres || umfpack || newton || rk || sdirk || sundials || petsc));
-   showElement("ex11", laplace && h1 && (galerkin || nurbs) && (lobpcg || amg || superlu));
-   showElement("ex12", elasticity && h1 && (galerkin || nurbs) && (lobpcg || amg));
-   showElement("ex13", maxwell && hcurl && galerkin && (lobpcg || ams));
-   showElement("ex14", laplace && l2 && dg && (gs || pcg || gmres || umfpack || amg));
-   showElement("ex15", laplace && h1 && (galerkin || nurbs || amr) && (gs || pcg || umfpack || amg));
-   showElement("ex16", conduction && h1 && galerkin && (pcg || jacobi || rk || sdirk || sundials));
-   showElement("ex17", elasticity && l2 && dg && (gs || pcg || gmres || umfpack || amg));
-   showElement("ex18", hydro && l2 && dg && (rk));
-   showElement("ex19", elasticity && h1 && mixed && (gs || gmres || newton || amg));
-   showElement("ex20", (elasticity || maxwell || conduction || hydro) && all2 && all3 && symplectic);
-   showElement("ex21", elasticity && h1 && (galerkin || amr) && (gs || pcg || umfpack || amg));
-   showElement("ex22", (laplace || maxwell || graddiv) && (h1 || hcurl || hdiv) && galerkin && (gmres || amg || ams || ads));
-   showElement("ex23", (laplace || wave) && h1 && (galerkin || nurbs) && newmark);
-   showElement("ex24", (graddiv) && (h1 || hcurl) && (galerkin || pa) && pcg);
-   showElement("ex25", (maxwell || wave) && hcurl && galerkin && (gmres || ams));
-   showElement("ex26", laplace && h1 && (galerkin || pa) && (jacobi || pcg || amg));
+   numShown = 0 // expression continued...
 
-   // Electromagnetic miniapps
-   numExamples += 4; // update when adding miniapps!
-   showElement("volta", maxwell && (l2 || hdiv) && (galerkin || amr) && (pcg || amg));
-   showElement("tesla", maxwell && (hdiv || hcurl) && (galerkin || amr) && (pcg || amg || ams));
-   showElement("maxwell", (maxwell || conduction || wave) && (hdiv || hcurl) && (galerkin || staticcond || mixed) && (pcg || symplectic));
-   showElement("joule", (maxwell || conduction) && (l2 || h1 || hdiv || hcurl) && (galerkin || amr || staticcond) && (pcg || amg || ams || ads || sdirk));
+   // example codes
+   + showElement("ex1",  (laplace) && h1 && (galerkin || nurbs || staticcond || pa) && (gs || pcg || umfpack || amg || petsc))
+   + showElement("ex2",  elasticity && h1 && (galerkin || nurbs || staticcond) && (gs || pcg || umfpack || amg || petsc))
+   + showElement("ex3",  (maxwell) && hcurl && (galerkin || staticcond || pa) && (gs || pcg || umfpack || ams || petsc))
+   + showElement("ex4",  graddiv && (hdiv || h12) && (galerkin || hybr || staticcond || pa) && (gs || pcg || umfpack || amg || ads || ams || petsc))
+   + showElement("ex5",  darcy && (l2 || hdiv) && (mixed || pa) && (gs || jacobi || minres || umfpack || amg  || petsc))
+   + showElement("ex6",  (laplace) && h1 && (galerkin || nurbs || amr || pa) && (gs || pcg || umfpack || amg || petsc))
+   + showElement("ex7",  (laplace || meshing) && h1 && (galerkin || amr) && (gs || pcg || umfpack || amg))
+   + showElement("ex8",  laplace && (l2 || h1 || h12) && dpg && (gs || pcg || umfpack || amg || ads || ams))
+   + showElement("ex9",  (advection) && l2 && (dg || pa) && (pcg || rk || sundials || petsc || hiop || gmres || sdirk))
+   + showElement("ex10", elasticity && (l2 || h1) && galerkin && (jacobi || pcg || minres || umfpack || newton || rk || sdirk || sundials || petsc))
+   + showElement("ex11", laplace && h1 && (galerkin || nurbs) && (lobpcg || amg || superlu))
+   + showElement("ex12", elasticity && h1 && (galerkin || nurbs) && (lobpcg || amg))
+   + showElement("ex13", maxwell && hcurl && galerkin && (lobpcg || ams))
+   + showElement("ex14", laplace && l2 && dg && (gs || pcg || gmres || umfpack || amg))
+   + showElement("ex15", laplace && h1 && (galerkin || nurbs || amr) && (gs || pcg || umfpack || amg))
+   + showElement("ex16", conduction && h1 && galerkin && (pcg || jacobi || rk || sdirk || sundials))
+   + showElement("ex17", elasticity && l2 && dg && (gs || pcg || gmres || umfpack || amg))
+   + showElement("ex18", hydro && l2 && dg && (rk))
+   + showElement("ex19", elasticity && h1 && mixed && (gs || gmres || newton || amg))
+   + showElement("ex20", (elasticity || maxwell || conduction || hydro) && all2 && all3 && symplectic)
+   + showElement("ex21", elasticity && h1 && (galerkin || amr) && (gs || pcg || umfpack || amg))
+   + showElement("ex22", (laplace || maxwell || graddiv) && (h1 || hcurl || hdiv) && galerkin && (gmres || amg || ams || ads))
+   + showElement("ex23", (laplace || wave) && h1 && (galerkin || nurbs) && newmark)
+   + showElement("ex24", (graddiv) && (h1 || hcurl) && (galerkin || pa) && pcg)
+   + showElement("ex25", (maxwell || wave) && hcurl && galerkin && (gmres || ams))
+   + showElement("ex26", laplace && h1 && (galerkin || pa) && (jacobi || pcg || amg))
 
-   // Meshing miniapps
-   numExamples += 11; // update when adding miniapps!
-   showElement("mobius-strip", meshing && all2 && all3 && all4);
-   showElement("klein-bottle", meshing && all2 && all3 && all4);
-   showElement("toroid", meshing && all2 && all3 && all4);
-   showElement("twist", meshing && all2 && all3 && all4);
-   showElement("extruder", meshing && all2 && all3 && all4);
-   showElement("shaper", meshing && all2 && all3 && all4);
-   showElement("mesh-explorer", meshing && all2 && all3 && all4);
-   showElement("mesh-optimizer", meshing && all2 && all3 && all4);
-   showElement("minimal-surface", meshing && all2 && (galerkin || amr || pa) && all4);
-   showElement("lor-transfer", meshing && (l2 || h1) && all3 && all4);
-   showElement("gslib-interpolation", meshing && all2 && all3 && all4);
+   // electromagnetic miniapps
+   + showElement("volta", maxwell && (l2 || hdiv) && (galerkin || amr) && (pcg || amg))
+   + showElement("tesla", maxwell && (hdiv || hcurl) && (galerkin || amr) && (pcg || amg || ams))
+   + showElement("maxwell", (maxwell || conduction || wave) && (hdiv || hcurl) && (galerkin || staticcond || mixed) && (pcg || symplectic))
+   + showElement("joule", (maxwell || conduction) && (l2 || h1 || hdiv || hcurl) && (galerkin || amr || staticcond) && (pcg || amg || ams || ads || sdirk))
 
-   // External miniapps
-   numExamples += 1; // update when adding miniapps!
-   showElement("laghos", (hydro) && (l2 || h1) && (galerkin || dg || pa) && (rk));
+   // meshing miniapps
+   + showElement("mobius-strip", meshing && all2 && all3 && all4)
+   + showElement("klein-bottle", meshing && all2 && all3 && all4)
+   + showElement("toroid", meshing && all2 && all3 && all4)
+   + showElement("twist", meshing && all2 && all3 && all4)
+   + showElement("extruder", meshing && all2 && all3 && all4)
+   + showElement("shaper", meshing && all2 && all3 && all4)
+   + showElement("mesh-explorer", meshing && all2 && all3 && all4)
+   + showElement("mesh-optimizer", meshing && all2 && all3 && all4)
+   + showElement("minimal-surface", meshing && all2 && (galerkin || amr || pa) && all4)
+   + showElement("lor-transfer", meshing && (l2 || h1) && all3 && all4)
+   + showElement("gslib-interpolation", meshing && all2 && all3 && all4)
 
-   numExamples += 1;
-   showElement("navier", (fluid) && (h1) && (galerkin || pa) && (gmres || pcg || amg));
+   // external miniapps
+   + showElement("laghos", (hydro) && (l2 || h1) && (galerkin || dg || pa) && (rk))
 
-   const miniappList = ["volta", "tesla", "maxwell", "joule", "mobius-strip", "klein-bottle", "toroid", "twist", "extruder",
-                        "shaper", "mesh-explorer", "mesh-optimizer", "minimal-surface", "lor-transfer", "gslib-interpolation",
-                        "laghos", "navier"]
+   + showElement("navier", (fluid) && (h1) && (galerkin || pa) && (gmres || pcg || amg))
 
-   var allHidden = true;
-   for (i = 1; i <= numExamples; i++) {
-      if (exampleVisible(i)) {
-         allHidden = false;
-         break;
-      }
-   }
+   ; // ...end of expression
 
-   if (miniappVisible(miniappList)) {
-      allHidden = false;
-   }
-
-   showElement("nomatch", allHidden);
+   // show/hide the message "No examples match your criteria"
+   showElement("nomatch", numShown == 0);
 }
 
 function initButtons()


### PR DESCRIPTION
Simplified filtering of examples/miniapps in the JavaScript at the end of `examples.md`.

Also tried to change the feature lists (radio buttons) to combo boxes, which seem cleaner now that the number of options is large.

Based on the `navier-miniapp` branch.