### PR TITLE
adding new LF

### DIFF
--- a/src/lininteg.md
+++ b/src/lininteg.md
@@ -83,6 +83,7 @@ and are denoted with $\left<\cdot,\cdot\right>$.
 | Class Name             | Space  | Operator                           | Continuous Op.   | Dimension  |
 |------------------------|--------|------------------------------------|------------------| ---------- |
 | DomainLFIntegrator     | H1, L2 | $(f, v)$ | $f$ | 1D, 2D, 3D |
+| DomainLFGradIntegrator | H1 |   $(\vec\{f}, \nabla v)$ | $-\nabla \cdot \vec\{f}$ | 1D, 2D, 3D |
 
 ### Boundary Integrators
 
@@ -108,6 +109,8 @@ and are denoted with $\left<\cdot,\cdot\right>$.
 |------------------------|--------|------------------------------------|------------------| ---------- |
 | VectorDomainLFIntegrator   | H1, L2 | $(\vec\{f}, \vec\{v})$  | $\vec\{f}$  | 1D, 2D, 3D |
 | VectorFEDomainLFIntegrator | ND, RT | $(\vec\{f}, \vec\{v})$  | $\vec\{f}$  | 2D, 3D |
+| VectorFEDomainLFCurlIntegrator | ND | $(\vec\{f}, \nabla \times v$) | $\nabla \times \vec\{f}$ | 2D, 3D |
+| VectorFEDomainLFDivIntegrator | RT | ($f, \nabla \cdot v $) | $ - \nabla f$ | 2D, 3D |
 
 ### Boundary Integrators
 

--- a/src/lininteg.md
+++ b/src/lininteg.md
@@ -109,8 +109,8 @@ and are denoted with $\left<\cdot,\cdot\right>$.
 |------------------------|--------|------------------------------------|------------------| ---------- |
 | VectorDomainLFIntegrator   | H1, L2 | $(\vec\{f}, \vec\{v})$  | $\vec\{f}$  | 1D, 2D, 3D |
 | VectorFEDomainLFIntegrator | ND, RT | $(\vec\{f}, \vec\{v})$  | $\vec\{f}$  | 2D, 3D |
-| VectorFEDomainLFCurlIntegrator | ND | $(\vec\{f}, \nabla \times v$) | $\nabla \times \vec\{f}$ | 2D, 3D |
-| VectorFEDomainLFDivIntegrator | RT | ($f, \nabla \cdot v $) | $ - \nabla f$ | 2D, 3D |
+| VectorFEDomainLFCurlIntegrator | ND | $(\vec\{f}, \nabla \times \vec\{v})$ | $\nabla \times \vec\{f}$ | 2D, 3D |
+| VectorFEDomainLFDivIntegrator | RT | $(f, \nabla \cdot \vec\{v})$ | $ - \nabla f$ | 2D, 3D |
 
 ### Boundary Integrators
 


### PR DESCRIPTION
Any opinions on how to represent correctly the Continuous Operator for the cases of 
`DomainLFGradIntegrator, VectorFEDomainLFCurlIntegrator, VectorFEDomainLFDivIntegrator` ? 
As is now the boundary contribution is omitted, as other BilinearFormIntegrators of similar nature (like WeakGrad, WeakDiv and WeakCurl integrators)  