### PR TITLE
CurlCurlIntegrator minor fix in description

### DIFF
--- a/src/bilininteg.md
+++ b/src/bilininteg.md
@@ -153,7 +153,7 @@ to assemble square linear operators.
 | Class Name             | Spaces | Coef.   | Operator                               | Continuous Op.                | Dimension  |
 |------------------------|--------|:-------:|----------------------------------------|-------------------------------|:----------:|
 | VectorFEMassIntegrator | ND, RT | S, D, M | $(\lambda\vec\{u},\vec\{v})$           | $\lambda\vec\{u}$             | 2D, 3D     |
-| CurlCurlIntegrator     | ND     |    S    | $(\lambda\curl\vec\{u},\curl\vec\{v})$ | $\curl(\lambda\curl\vec\{u})$ | 2D, 3D     |
+| CurlCurlIntegrator     | ND     | S, M    | $(\lambda\curl\vec\{u},\curl\vec\{v})$ | $\curl(\lambda\curl\vec\{u})$ | 2D, 3D     |
 | DivDivIntegrator       | RT     |    S    | $(\lambda\div\vec\{u},\div\vec\{v})$   | $-\grad(\lambda\div\vec\{u})$ | 2D, 3D     |
 
 ### Mixed Operators

--- a/src/bilininteg.md
+++ b/src/bilininteg.md
@@ -196,7 +196,7 @@ These integrators are designed to be used with the MixedBilinearForm object to a
 These operators require vector-valued basis functions constructed by
 using multiple copies of scalar fields.  In each of these integrators
 the scalar basis function index increments most quickly followed by
-the vector index.  This leads to local element matrix which have a
+the vector index.  This leads to local element matrices that have a
 block structure.
 
 ### Square Operators


### PR DESCRIPTION
The `CurlCurlIntegrator` supports `MatrixCoefficient`. It is used in that way, for example, in ex25. This was added in https://github.com/mfem/mfem/commit/4d737d0358f2c6b07b16152b45294f00e57dd96f.