### PR TITLE
Link updates to news.md

### DIFF
--- a/src/news.md
+++ b/src/news.md
@@ -27,11 +27,11 @@ Mar 1, 2018  | MFEM highlighted in LLNL's [Science & Technology Review](https://
 Dec 30, 2017 | Initial version of [libCEED](https://github.com/CEED/libCEED), the low-level CEED API, released.
 Nov 10, 2017 | Version 3.3.2 [released](https://github.com/mfem/mfem/blob/v3.3.2/CHANGELOG).
 Nov 7, 2017  | ECP article: [Co-Design Center Develops Next-Generation Simulation Tools](https://www.exascaleproject.org/co-design-center-develops-next-generation-simulation-libraries-and-mini-apps/), also in [HPCwire](https://www.hpcwire.com/2017/11/08/co-design-center-develops-next-generation-simulation-tools/).
-Oct 30, 2017 | Laghos part of the [ECP Proxy App Suite 1.0](https://exascaleproject.github.io/proxy-apps/ecp-apps/), [CORAL-2 Benchmarks](https://asc.llnl.gov/coral-2-benchmarks/) and [ASC co-design miniapps](https://codesign.llnl.gov/laghos.php).
+Oct 30, 2017 | Laghos part of the [ECP Proxy App Suite 1.0](https://exascaleproject.github.io/proxy-apps/ecp-apps/), [CORAL-2 Benchmarks](https://asc.llnl.gov/coral-2-benchmarks/) and [ASC co-design miniapps](https://computing.llnl.gov/projects/co-design/laghos).
 Oct 16, 2017 | Postdoc position [available](http://careers-llnl.ttcportals.com/jobs/8037517-postdoctoral-research-staff-member) for electromagnetic simulations with MFEM.
 Sep 22, 2017 | LLNL Newsline: [LLNL gears up for next generation of computer-aided design and engineering](https://www.llnl.gov/news/llnl-gears-next-generation-computer-aided-design-and-engineering).
 Jun 15, 2017 | [Laghos](https://github.com/ceed/Laghos) miniapp and [CEED benchmarks](http://ceed.exascaleproject.org/bps/) released.
-May 8, 2017  | News highlight: [Accelerating Simulation Software with Graphics Processing Units](https://computation.llnl.gov/newsroom/accelerating-simulation-software-graphics-processing-units).
+May 8, 2017  | News highlight: Accelerating Simulation Software with Graphics Processing Units.
 Feb 16, 2017 | Moved main development to GitHub.
 Jan 28, 2017 | Version 3.3 [released](https://github.com/mfem/mfem/blob/v3.3/CHANGELOG).
 Dec 15, 2016 | [Postdoc position](http://careers-ext.llnl.gov/jobs/6264056-post-dr-research-staff-1) for [exascale computing](https://exascaleproject.org/2016/11/11/ecp_co-design_centers) with MFEM.
@@ -41,10 +41,10 @@ Oct 6, 2016 | [Science & Technology Review](https://str.llnl.gov/september-2016)
 Sep 19, 2016 |[PyMFEM](https://github.com/MFEM/PyMFEM) - a Python wrapper for MFEM by [Syun'ichi Shiraiwa](https://www.psfc.mit.edu/people/scientific-staff/syun-ichi-shiraiwa) from MIT's Plasma Science and Fusion Center released.
 Jun 30, 2016 | Version 3.2 [released](https://github.com/mfem/mfem/blob/v3.2/CHANGELOG).
 May 6, 2016  | MFEM packages available in [homebrew](https://github.com/Homebrew/homebrew-science) and [spack](https://github.com/LLNL/spack).
-Mar 9, 2016  | VisIt 2.10.1 [released](http://software.llnl.gov/news/2016/03/09/visit-2.10.1) with MFEM 3.1 support.
+Mar 9, 2016  | VisIt 2.10.1 [released](https://software.llnl.gov/news/2016/03/09/visit-2.10.1/) with MFEM 3.1 support.
 Mar 4, 2016  | New LLNL open-source software [Blog](http://software.llnl.gov/news) and [Twitter](https://twitter.com/LLNL_OpenSource).
 Feb 16, 2016 | Version 3.1 [released](https://github.com/mfem/mfem/blob/v3.1/CHANGELOG).
 Feb 5, 2016  | MFEM simulation images part of the [Art of Science](https://www.llnl.gov/news/media-advisory-laboratory-showcases-art-science-livermore-library) exhibition at the Livermore public library.
-Jan 6, 2016  | News highlight: [High-order finite element library provides scientists with access to cutting-edge algorithms](http://computation.llnl.gov/newsroom/high-order-finite-element-library-provides-scientists-access-cutting-edge-algorithms).
+Jan 6, 2016  | News highlight: High-order finite element library provides scientists with access to cutting-edge algorithms.
 Aug 18, 2015 | Moved to [GitHub](https://github.com/mfem/mfem) and [mfem.org](http://mfem.org).
 Jan 26, 2015 | Version 3.0 [released](https://github.com/mfem/mfem/blob/v3.0/CHANGELOG).


### PR DESCRIPTION
In preparation for the new redesign/overhaul of computing.llnl.gov, I unpublished all news on _that_ website dated before 1/1/19 (Comp web team is only keeping 2 years' worth of news). That action resulted in two broken news links on _this_ website. I unlinked those and, while I had news.md open, checked/updated all the other *.llnl.gov links.