### PR TITLE
Fixed broken links in news

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -27,11 +27,12 @@ See also our [Gallery](gallery.md), [Publications](publications.md) and
 
 Date         | Message
 ------------ | -----------------------------------------------------------------
+Mar 18, 2021 | [Postdoc position](https://www.llnl.gov/join-our-team/careers/find-your-job/all/mfem/3743990000038667) using MFEM.
 Feb 16, 2021 | New page on [GPU performance](gpu-tips-n-tricks.md).
 Dec 19, 2020 | [PyMFEM](https://github.com/mfem/PyMFEM) available with [`pip install mfem`](https://pypi.org/project/mfem).
 Oct 30, 2020 | Version 4.2 [released](https://github.com/mfem/mfem/blob/v4.2/CHANGELOG).
-Jul 11, 2020 | MFEM paper [appeared](http://doi.org/10.1016/j.camwa.2020.06.009) in CAMWA.
 
+[comment]: # (Jul 11, 2020 | MFEM paper [appeared](http://doi.org/10.1016/j.camwa.2020.06.009) in CAMWA.)
 [comment]: # (Jun 24, 2020 | MFEM [video](https://www.youtube.com/watch?v=Rpccj3NopSE) available on YouTube.)
 [comment]: # (Jun 8, 2020  | ECP [podcast](https://www.exascaleproject.org/major-update-of-the-mfem-finite-element-library-broadens-gpu-support/) about mfem-4.1.)
 [comment]: # (Mar 10, 2020 | Version 4.1 [released](https://github.com/mfem/mfem/blob/v4.1/CHANGELOG).)

--- a/src/news.md
+++ b/src/news.md
@@ -2,6 +2,7 @@
 
 &nbsp;       | |
 ------------ | -----------------------------------------------------------------
+Mar 18, 2021 | Postdoc position [available](https://www.llnl.gov/join-our-team/careers/find-your-job/all/mfem/3743990000038667) for R&D of advanced finite element methods for multi-physics simulation codes using MFEM.
 Feb 16, 2021 | New documentation page on [GPU performance](gpu-tips-n-tricks.md).
 Dec 19, 2020 | [PyMFEM](https://github.com/mfem/PyMFEM) available with [`pip install mfem`](https://pypi.org/project/mfem).
 Oct 30, 2020 | Version 4.2 [released](https://github.com/mfem/mfem/blob/v4.2/CHANGELOG).
@@ -29,23 +30,23 @@ Dec 30, 2017 | Initial version of [libCEED](https://github.com/CEED/libCEED), th
 Nov 10, 2017 | Version 3.3.2 [released](https://github.com/mfem/mfem/blob/v3.3.2/CHANGELOG).
 Nov 7, 2017  | ECP article: [Co-Design Center Develops Next-Generation Simulation Tools](https://www.exascaleproject.org/co-design-center-develops-next-generation-simulation-libraries-and-mini-apps/), also in [HPCwire](https://www.hpcwire.com/2017/11/08/co-design-center-develops-next-generation-simulation-tools/).
 Oct 30, 2017 | Laghos part of the [ECP Proxy App Suite 1.0](https://exascaleproject.github.io/proxy-apps/ecp-apps/), [CORAL-2 Benchmarks](https://asc.llnl.gov/coral-2-benchmarks/) and [ASC co-design miniapps](https://computing.llnl.gov/projects/co-design/laghos).
-Oct 16, 2017 | Postdoc position [available](http://careers-llnl.ttcportals.com/jobs/8037517-postdoctoral-research-staff-member) for electromagnetic simulations with MFEM.
+Oct 16, 2017 | Postdoc position available for electromagnetic simulations with MFEM.
 Sep 22, 2017 | LLNL Newsline: [LLNL gears up for next generation of computer-aided design and engineering](https://www.llnl.gov/news/llnl-gears-next-generation-computer-aided-design-and-engineering).
 Jun 15, 2017 | [Laghos](https://github.com/ceed/Laghos) miniapp and [CEED benchmarks](http://ceed.exascaleproject.org/bps/) released.
-May 8, 2017  | News highlight: [Accelerating Simulation Software with Graphics Processing Units](https://computing.llnl.gov/sites/default/files/public/Computation%20Annual%20Report2016_MFEM.pdf).
+May 8, 2017  | News highlight: [Accelerating Simulation Software with Graphics Processing Units](https://computing.llnl.gov/sites/default/files/Computation%20Annual%20Report2016_MFEM.pdf).
 Feb 16, 2017 | Moved main development to GitHub.
 Jan 28, 2017 | Version 3.3 [released](https://github.com/mfem/mfem/blob/v3.3/CHANGELOG).
 Dec 15, 2016 | [Postdoc position](http://careers-ext.llnl.gov/jobs/6264056-post-dr-research-staff-1) for [exascale computing](https://exascaleproject.org/2016/11/11/ecp_co-design_centers) with MFEM.
 Nov 11, 2016 | MFEM part of the new [ECP](https://exascaleproject.org) co-design [Center for Efficient Exascale Discretizations (CEED)](http://ceed.exascaleproject.org).
 Nov 11, 2016 | LLNL Newsline: [Lawrence Livermore tapped to lead co-design center for exascale computing ecosystem](https://www.llnl.gov/news/lawrence-livermore-tapped-lead-%E2%80%98co-design%E2%80%99-center-exascale-computing-ecosystem).
 Oct 6, 2016 | [Science & Technology Review](https://str.llnl.gov/september-2016) article: [Laying the Groundwork for Extreme-Scale Computing](https://str.llnl.gov/content/pages/september-2016/pdf/09.16.1.pdf), see also the [YouTube preview](http://www.youtube.com/watch?v=ePWyiDf_XTg).
-Sep 19, 2016 |[PyMFEM](https://github.com/MFEM/PyMFEM) - a Python wrapper for MFEM by [Syun'ichi Shiraiwa](https://www.psfc.mit.edu/people/scientific-staff/syun-ichi-shiraiwa) from MIT's Plasma Science and Fusion Center released.
+Sep 19, 2016 |[PyMFEM](https://github.com/MFEM/PyMFEM) - a Python wrapper for MFEM by [Syun'ichi Shiraiwa](https://github.com/sshiraiwa) from MIT's Plasma Science and Fusion Center released.
 Jun 30, 2016 | Version 3.2 [released](https://github.com/mfem/mfem/blob/v3.2/CHANGELOG).
-May 6, 2016  | MFEM packages available in [homebrew](https://github.com/Homebrew/homebrew-science) and [spack](https://github.com/LLNL/spack).
+May 6, 2016  | MFEM packages available in [homebrew](https://github.com/Homebrew) and [spack](https://github.com/LLNL/spack).
 Mar 9, 2016  | VisIt 2.10.1 [released](https://software.llnl.gov/news/2016/03/09/visit-2.10.1/) with MFEM 3.1 support.
 Mar 4, 2016  | New LLNL open-source software [Blog](http://software.llnl.gov/news) and [Twitter](https://twitter.com/LLNL_OpenSource).
 Feb 16, 2016 | Version 3.1 [released](https://github.com/mfem/mfem/blob/v3.1/CHANGELOG).
 Feb 5, 2016  | MFEM simulation images part of the [Art of Science](https://www.llnl.gov/news/media-advisory-laboratory-showcases-art-science-livermore-library) exhibition at the Livermore public library.
-Jan 6, 2016  | News highlight: [High-order finite element library provides scientists with access to cutting-edge algorithms](https://computing.llnl.gov/sites/default/files/public/High-Order%20Finite%20Element%20Library%20Provides%20Scientists%20with%20Access%20to%20Cutting-Edge%20Algorithms.pdf).
+Jan 6, 2016  | News highlight: [High-order finite element library provides scientists with access to cutting-edge algorithms](https://computing.llnl.gov/sites/default/files/High-Order%20Finite%20Element%20Library%20Provides%20Scientists%20with%20Access%20to%20Cutting-Edge%20Algorithms.pdf).
 Aug 18, 2015 | Moved to [GitHub](https://github.com/mfem/mfem) and [mfem.org](http://mfem.org).
 Jan 26, 2015 | Version 3.0 [released](https://github.com/mfem/mfem/blob/v3.0/CHANGELOG).


### PR DESCRIPTION
My link crawler on computing.llnl.gov caught something that inspired me to check MFEM news links. So I ran a link checker on https://mfem.org/news/ and found several broken links, two from Computing (the file path for downloadable PDFs changed when the new site launched in March). 

Mar 18, 2021 - added new postdoc job opening (also added to index.md)
Oct 16, 2017 - unlinked old job posting
May 8, 2017 - updated Computing file path
Sep 19, 2016 - person no longer at MIT; linked to their GitHub profile instead
May 6, 2016 - linked to main Homebrew repo
Jan 6, 2016 -  updated Computing file path