### PR TITLE
Updated videos page with 1st seminar video

### DIFF
--- a/src/seminar.md
+++ b/src/seminar.md
@@ -64,7 +64,7 @@ Fill in [this form](https://docs.google.com/forms/d/e/1FAIpQLScrJ9QT7v7abx2ELcET
 &nbsp;&nbsp;
 [<button type="button" class="btn btn-success">
 **Talk Recording**
-</button>](videos.md)
+</button>](https://www.youtube.com/watch?v=WJ5dAhOR6Gg&list=PLy9rIbGDXrG1Lfy3Um-KEPqFae7Ipghqj&index=1)
 
 **Abstract:** Immersed/embedded/unfitted boundary methods obviate the need for continual re-meshing in many applications involving rapid prototyping and design. Unfortunately, many finite element embedded boundary methods are also difficult to implement due to the need to perform complex cell cutting operations at boundaries, and the consequences that these operations may have on the overall conditioning of the ensuing algebraic problems. We present a new, stable, and simple embedded boundary method, named “shifted boundary method” (SBM), which eliminates the need to perform cell cutting. Boundary conditions are imposed on a surrogate discrete boundary, lying on the interior of the true boundary interface. We then construct appropriate field extension operators, by way of Taylor expansions, with the purpose of preserving accuracy when imposing the boundary conditions. We demonstrate the SBM on large-scale solid and fracture mechanics problems; thermomechanics problems; porous media flow problems; incompressible flow problems governed by the Navier-Stokes equations (also including free surfaces); and problems governed by hyperbolic conservation laws.
 

--- a/src/seminar.md
+++ b/src/seminar.md
@@ -2,7 +2,7 @@
 
 # FEM@LLNL Seminar Series
 
-We are happy to announce a new FEM@LLNL seminar series, starting in 2022, which will focus on finite element research and applications talks of interest to the MFEM community. We have lined up some excellent speakers for our first year and plan to keep adding more.
+We are happy to announce a new FEM@LLNL seminar series, starting in 2022, which will focus on finite element research and applications talks of interest to the MFEM community. We have lined up some excellent speakers for our first year and plan to keep adding more. Videos will be added to a [YouTube playlist](https://www.youtube.com/playlist?list=PLy9rIbGDXrG1Lfy3Um-KEPqFae7Ipghqj) as well as this site's [videos page](videos.md).
 
 
 ### <i class="fa fa-envelope-o" aria-hidden="true"></i> Sign-Up

--- a/src/videos.md
+++ b/src/videos.md
@@ -2,13 +2,13 @@
 
 A collection of MFEM-related videos, including recorded talks from the MFEM workshops and conference presentations.
 
-## FEM@LLNL Seminar Series
+## FEM@LLNL Seminar
 
 ---
 
 <div class="col-md-6"  markdown="1">
 
-#### Guglielmo Scovazzi (Duke University)
+#### Guglielmo Scovazzi (Duke)
 #### *The Shifted Boundary Method: An Immersed Approach for Computational Mechanics*
 ##### **January 20, 2022** | [FEM@LLNL Seminar Series](https://mfem.org/seminar)
 

--- a/src/videos.md
+++ b/src/videos.md
@@ -2,11 +2,27 @@
 
 A collection of MFEM-related videos, including recorded talks from the MFEM workshops and conference presentations.
 
-## MFEM Workshop 2021
+## FEM@LLNL Seminar Series
 
 ---
 
 <div class="col-md-6"  markdown="1">
+
+#### Guglielmo Scovazzi (Duke University)
+#### *The Shifted Boundary Method: An Immersed Approach for Computational Mechanics*
+##### **January 20, 2022** | [FEM@LLNL Seminar Series](https://mfem.org/seminar)
+
+![YouTube](WJ5dAhOR6Gg)
+
+Immersed/embedded/unfitted boundary methods obviate the need for continual re-meshing in many applications involving rapid prototyping and design. Unfortunately, many finite element embedded boundary methods are also difficult to implement due to the need to perform complex cell cutting operations at boundaries, and the consequences that these operations may have on the overall conditioning of the ensuing algebraic problems. We present a new, stable, and simple embedded boundary method, named “shifted boundary method” (SBM), which eliminates the need to perform cell cutting. Boundary conditions are imposed on a surrogate discrete boundary, lying on the interior of the true boundary interface. We then construct appropriate field extension operators, by way of Taylor expansions, with the purpose of preserving accuracy when imposing the boundary conditions. We demonstrate the SBM on large-scale solid and fracture mechanics problems; thermomechanics problems; porous media flow problems; incompressible flow problems governed by the Navier-Stokes equations (also including free surfaces); and problems governed by hyperbolic conservation laws.
+
+</div><div class="col-md-12"  markdown="1">
+
+## MFEM Workshop 2021
+
+---
+
+</div><div class="col-md-6"  markdown="1">
 
 #### Aaron Fisher (LLNL)
 #### *Wrap-Up and Simulation Contest Winners*


### PR DESCRIPTION
- Added Dr. Scovazzi video to `videos.md` including a new H2 heading
- Added YouTube playlist link to `seminar.md` plus a link over to `videos.md`
- Replaced placeholder link in green "Talk Recording" button on `seminar.md`

His abstract now appears in two places (`seminar.md` & `videos.md`). Redundancy OK? 

Page will look a little lopsided until the 2nd video is posted.

![image](https://user-images.githubusercontent.com/31740953/153497246-0637eecc-c3c5-4231-8869-3ba1b92c569f.png)
