### PR TITLE
Updated videos & seminar pages

### DIFF
--- a/src/seminar.md
+++ b/src/seminar.md
@@ -65,7 +65,7 @@ Fill in [this form](https://docs.google.com/forms/d/e/1FAIpQLScrJ9QT7v7abx2ELcET
 &nbsp;&nbsp;
 [<button type="button" class="btn btn-success">
 **Talk Recording**
-</button>](videos.md)
+</button>](https://www.youtube.com/watch?v=edK62yPUtIs&list=PLy9rIbGDXrG1Lfy3Um-KEPqFae7Ipghqj&index=4)
 
 **Abstract:** Two operations take function spaces and make them suitable for finite element computations. The first is the construction of trace-free subspaces (which creates "bubble" functions) and the second is the extension of functions from cell boundaries into cell interiors (which create edge functions with the correct continuity): together these operations define the _geometric decomposition_ of a function space. In finite element exterior calculus (FEEC), these two operations have been treated separately for the two main families of finite elements: full polynomial elements and trimmed polynomial elements. In this talk we will see how one constructor of trace-free functions and one extension operator can be used for both families, and indeed for all differential forms. We will also examine the practicality of these two operators as tools for implementing geometric decompositions in actual finite element codes.
 

--- a/src/videos.md
+++ b/src/videos.md
@@ -2,14 +2,34 @@
 
 A collection of MFEM-related videos, including recorded talks from the MFEM workshops and conference presentations.
 
-## FEM@LLNL Seminar
+## FEM@LLNL Seminars
 
 ---
 
 <div class="col-md-6"  markdown="1">
 
+#### Tobin Isaac (Georgia Tech)
+#### *Unifying the Analysis of Geometric Decomposition in FEEC*
+##### **March 22, 2022** | [FEM@LLNL Seminar Series](https://mfem.org/seminar)
+
+![YouTube](edK62yPUtIs)
+
+Two operations take function spaces and make them suitable for finite element computations. The first is the construction of trace-free subspaces (which creates "bubble" functions) and the second is the extension of functions from cell boundaries into cell interiors (which create edge functions with the correct continuity): together these operations define the _geometric decomposition_ of a function space. In finite element exterior calculus (FEEC), these two operations have been treated separately for the two main families of finite elements: full polynomial elements and trimmed polynomial elements. In this talk we will see how one constructor of trace-free functions and one extension operator can be used for both families, and indeed for all differential forms. We will also examine the practicality of these two operators as tools for implementing geometric decompositions in actual finite element codes.
+
+</div><div class="col-md-6"  markdown="1">
+
+#### Raphaël Zanella (UT Austin)
+#### *Axisymmetric MFEM-based solvers for the compressible Navier-Stokes equations and other problems*
+##### **March 1, 2022** | [FEM@LLNL Seminar Series](https://mfem.org/seminar)
+
+![YouTube](qCW60wWmv4Y)
+
+An axisymmetric model leads, when suitable, to a substantial cut in the computational cost with respect to a 3D model. Although not as accurate, the axisymmetric model allows to quickly obtain a result which can be satisfying. Simple modifications to a 2D finite element solver allow to obtain an axisymmetric solver. We present MFEM-based parallel axisymmetric solvers for different problems. We first present simple axisymmetric solvers for the Laplacian problem and the heat equation. We then present an axisymmetric solver for the compressible Navier-Stokes equations. All solvers are based on H^1-conforming finite element spaces. The correctness of the implementation is verified with convergence tests on manufactured solutions. The Navier-Stokes solver is used to simulate axisymmetric flows with an analytical solution (Poiseuille and Taylor-Couette) and an air flow in a plasma torch geometry.
+
+</div><div class="col-md-6"  markdown="1">
+
 #### Robert Carson (LLNL)
-##### *An overview of ExaConstit and its use in the ExaAM project*
+#### *An overview of ExaConstit and its use in the ExaAM project*
 ##### **February 1, 2022** | [FEM@LLNL Seminar Series](https://mfem.org/seminar)
 
 ![YouTube](I0kTJdR8oZU)
@@ -25,6 +45,22 @@ As additively manufactured (AM) parts become increasingly more popular in indust
 ![YouTube](WJ5dAhOR6Gg)
 
 Immersed/embedded/unfitted boundary methods obviate the need for continual re-meshing in many applications involving rapid prototyping and design. Unfortunately, many finite element embedded boundary methods are also difficult to implement due to the need to perform complex cell cutting operations at boundaries, and the consequences that these operations may have on the overall conditioning of the ensuing algebraic problems. We present a new, stable, and simple embedded boundary method, named “shifted boundary method” (SBM), which eliminates the need to perform cell cutting. Boundary conditions are imposed on a surrogate discrete boundary, lying on the interior of the true boundary interface. We then construct appropriate field extension operators, by way of Taylor expansions, with the purpose of preserving accuracy when imposing the boundary conditions. We demonstrate the SBM on large-scale solid and fracture mechanics problems; thermomechanics problems; porous media flow problems; incompressible flow problems governed by the Navier-Stokes equations (also including free surfaces); and problems governed by hyperbolic conservation laws.
+
+</div><div class="col-md-12"  markdown="1">
+
+## Conferences in 2022
+
+---
+
+</div><div class="col-md-6"  markdown="1">
+
+#### John Camier (LLNL)
+#### *All-Out Kernel Fusion: Reaching Peak Performance Faster in High-Order Finite Element Simulations*
+##### **March 21–24, 2022** | [NVIDIA GTC22](https://www.nvidia.com/gtc/)
+
+![YouTube](M2a1eW9XMJQ)
+
+LLNL research scientist John Camier described recent improvements of high-order finite element CUDA kernels that can reduce the time-to-solution by a factor of 10. Augmenting traditional compiler representations with a general mathematical description enables a sustainable way to generate optimized kernels, matching the peak performance of hand-tuned CUDA code. Such intermediate graph-based representation provides significant potential for optimization, both in terms of minimizing the number of kernel launches and in reducing the memory bandwidth. Camier also presented results on single and multiple GPUs that demonstrate significant reduction in the local problem size required to reach peak performance, leading to faster time-to-solution in finite element applications.
 
 </div><div class="col-md-12"  markdown="1">
 


### PR DESCRIPTION
1. Added new new "Conferences in 2022" heading to videos page; I placed this after the seminar series because the latter spans 2021-22
2. Added Camier GTC video link/abstract to videos page under new heading
3. Added Zanella and Isaac links/abstracts to videos page
4. Made title heading levels consistent among seminar videos (4 # instead of 5)
5. Updated Isaac link on seminar page