### PR TITLE
Highlight the GPU support table

### DIFF
--- a/src/bilininteg.md
+++ b/src/bilininteg.md
@@ -386,5 +386,9 @@ information.
 | MixedScalarWeakGradientIntegrator   | $(-\lambda u, \div\vec\{v})$                        | $\grad(\lambda u)$                   | $-\lambda u\,\hat\{n}$                   |
 | MixedWeakGradDotIntegrator          | $(-\vec\{\lambda}\cdot\vec\{u},\div\vec\{v})$       | $\grad(\vec\{\lambda}\cdot\vec\{u})$ | $-\vec\{\lambda}\cdot\vec\{u}\,\hat\{n}$ |
 
+## Device support
+
+A list of the MFEM integrators that support device acceleration is available [here](howto/assembly_levels.md#device-support).
+
 <script type="text/x-mathjax-config">MathJax.Hub.Config({TeX: {equationNumbers: {autoNumber: "all"}}, tex2jax: {inlineMath: [['$','$']]}});</script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS_HTML"></script>

--- a/src/gpu-support.md
+++ b/src/gpu-support.md
@@ -18,6 +18,8 @@ MFEM_FORALL(i, u.Size(),     // Abstract the loop: for(int i=0; i<u.Size(); i++)
 });
 ```
 
+A list of the MFEM integrators that support device acceleration is available [here](howto/assembly_levels.md#device-support).
+
 ## Memory manager
 In order to make the use of host/device memory as simple as possible, MFEM relies on internal memory manager.
 Instead of storing a pointer of type `T*`, each object that can be accessed on a device contains `Memory<T>` objects.

--- a/src/howto/assembly_levels.md
+++ b/src/howto/assembly_levels.md
@@ -50,6 +50,7 @@ It is also possible to request the backend of a backend, for instance if we want
 mfem::Device device("ceed-cuda:/gpu/cuda/shared");
 ```
 
+# Device support
 The native MFEM backend and the RAJA backend support the same features and Integrators. However, the OCCA backend, and the libCEED backend each offer different features, and support different Integrators with different performance characteristics.
 
 | Supported Integrators             | native MFEM | OCCA backend | libCEED backend |


### PR DESCRIPTION
Addresses this TODO item:

- Add a table for GPU coverage of bilinear/linear forms (Add a link to [this page](https://mfem.org/howto/assembly_levels/) from [GPU support](https://mfem.org/gpu-support/) and [BilinInteg](https://mfem.org/bilininteg/))