### PR TITLE
A small fix in the bib item on the 'about' page

### DIFF
--- a/src/about.md
+++ b/src/about.md
@@ -7,7 +7,7 @@ Please cite with:
 @article{mfem,
   title = {{MFEM}: A Modular Finite Element Methods Library},
   author = {R. Anderson and J. Andrej and A. Barker and J. Bramwell and J.-S. Camier and
-            J. Cerveny V. Dobrev and Y. Dudouit and A. Fisher and Tz. Kolev and W. Pazner and
+            J. Cerveny and V. Dobrev and Y. Dudouit and A. Fisher and Tz. Kolev and W. Pazner and
             M. Stowell and V. Tomov and I. Akkerman and J. Dahm and D. Medina and S. Zampini},
   journal = {Computers \& Mathematics with Applications},
   doi = {10.1016/j.camwa.2020.06.009},


### PR DESCRIPTION
There was a missing "and".