### PR TITLE
Add news item for August tutorial

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -92,10 +92,10 @@ See also our [Gallery](gallery.md), [Publications](publications.md), [Videos](vi
 
 Date         | Message
 ------------ | -----------------------------------------------------------------
+ Jun 5, 2024 | [Register](https://hpcic.llnl.gov/tutorials/2024-hpc-tutorials) for MFEM [tutorial](tutorial.md) on Aug 22.
  May 7, 2024 | Version 4.7 [released](https://github.com/mfem/mfem/blob/v4.7/CHANGELOG).
  May 2, 2024 | New MFEM [paper](https://arxiv.org/abs/2402.15940) in IJHPCA.
 Oct 26, 2023 | 2023 [MFEM Community Workshop](workshop.md).
-Sep 11, 2023 | MFEM now available in [Homebrew](https://formulae.brew.sh/formula/mfem).
 Feb 22, 2023 | AWS releases [Palace](https://aws.amazon.com/blogs/quantum-computing/aws-releases-open-source-software-palace-for-cloud-based-electromagnetics-simulations-of-quantum-computing-hardware/) based on MFEM.
 
 ## Latest Release

--- a/src/news.md
+++ b/src/news.md
@@ -2,8 +2,9 @@
 
 <img width=130px, style="margin:-10px"> | |
 ------------ | -----------------------------------------------------------------
+**Jun 5, 2024** | *MFEM in the cloud [tutorial](tutorial/index.md) as part of the [HPCIC Tutorial](https://hpcic.llnl.gov/tutorials/2024-hpc-tutorials) series.*
 **May 7, 2024** | *Version 4.7 [released](https://github.com/mfem/mfem/blob/v4.7/CHANGELOG).*
-**May 2, 2024** |  New MFEM [paper](https://arxiv.org/abs/2402.15940) to appear in the International Journal of High Performance Computing Application.
+**May 2, 2024** |  *New MFEM [paper](https://arxiv.org/abs/2402.15940) to appear in the International Journal of High Performance Computing Application.*
 **Nov 13, 2023** | *[Recap](https://computing.llnl.gov/about/newsroom/mfem-workshop-2023) of the [2023 Workshop](workshop.md), held on October 26.*
 **Oct 26, 2023** | *2023 [MFEM community workshop](workshop.md).*
 **Sep 27, 2023** | *Version 4.6 [released](https://github.com/mfem/mfem/blob/v4.6/CHANGELOG).*

--- a/src/tutorial/index.md
+++ b/src/tutorial/index.md
@@ -1,10 +1,10 @@
 # MFEM Tutorial on AWS
-<!-- <h4>August 15, 2022</h4> -->
+<!-- <h4>August 22, 2024</h4> -->
 
 ![MFEM on AWS](img/mfem-aws.png)
 
 Welcome to the MFEM tutorial, part of the
-[RADIUSS Tutorial Series](https://software.llnl.gov/radiuss/event/2023/07/11/radiuss-on-aws/)
+[HPCIC Tutorial Series](https://hpcic.llnl.gov/tutorials/2024-hpc-tutorials)
 in collaboration with [AWS](https://aws.amazon.com/blogs/hpc/call-for-participation-radiuss-tutorial-series-2023/).
 
 [MFEM](https://mfem.org/) is a modular parallel C++ library for finite element


### PR DESCRIPTION
The AWS blog link on the tutorial page (line 8) still points to the 2023 blog post. A 2024 post is coming soon.