### PR TITLE
Improve the notation for boundary integrators/operators

### DIFF
--- a/src/bilininteg.md
+++ b/src/bilininteg.md
@@ -226,7 +226,7 @@ block structure.
 | DGDiffusionIntegrator     | H1, L2 | H1, L2 | $-\left<\\\{Q\grad u\cdot\hat\{n}\\\},[v]\right> \\\\ + \sigma \left<[u],\\\{Q\grad v\cdot\hat\{n}\\\}\right> \\\\ + \kappa \left<\\\{h^\{-1}Q\\\}[u],[v]\right> $ | |
 | DGElasticityIntegrator    | H1, L2 | H1, L2 | see $(\ref\{dg-elast})$ | |
 | TraceJumpIntegrator       |        |        | $\left< v, [w] \right>$ | |
-| NormalTraceJumpIntegrator |        |        | $\left< v, \left[\vec\{w}\cdot \vec\{n}\right] \right>$ | |
+| NormalTraceJumpIntegrator |        |        | $\left< v, \left[\vec\{w}\cdot \hat\{n}\right] \right>$ | |
 
 Integrator for the DG elasticity form, for the formulations see:
 
@@ -246,13 +246,13 @@ where $ \left< u, v\right> = \int_\{F} u \cdot v $, and $ F $ is a
     an interior face $ F_i $ separating elements $ K_1 $ and $ K_2 $.
 
 In the bilinear form above $ \tau(u) $ is traction, and it's also
-    $ \tau(u) = \sigma(u) \cdot \vec\{n} $, where $ \sigma(u) $ is
-    stress, and $ \vec\{n} $ is the unit normal vector w.r.t. to $ F $.
+    $ \tau(u) = \sigma(u) \cdot \hat\{n} $, where $ \sigma(u) $ is
+    stress, and $ \hat\{n} $ is the unit normal vector w.r.t. to $ F $.
 
 In other words, we have
     $$\label\{dg-elast}
-    - \left< \\{ \sigma(u) \cdot \vec\{n} \\}, [v] \right> + \alpha \left< \\{
-        \sigma(v) \cdot \vec\{n} \\}, [u] \right> + \kappa \left< h^{-1} \\{
+    - \left< \\{ \sigma(u) \cdot \hat\{n} \\}, [v] \right> + \alpha \left< \\{
+        \sigma(v) \cdot \hat\{n} \\}, [u] \right> + \kappa \left< h^{-1} \\{
         \lambda + 2 \mu \\} [u], [v] \right>
     $$
 

--- a/src/bilininteg.md
+++ b/src/bilininteg.md
@@ -348,7 +348,7 @@ equal to zero.  On the other hand a non-homogeneous Neumann boundary
 condition can be applied by using a linear form boundary integrator to
 compute this boundary term for a known function e.g. when using the
 `CurlCurlIntegrator` one could provide a known function for
-$\lambda\,\curl\vec\{u}$ to the `VectorFEBoundaryTangentLFIntegrator`
+$-\lambda\,\curl\vec\{u}$ to the `VectorFEBoundaryTangentLFIntegrator`
 which would then integrate the product of the tangential portion of
 this function with that of the ND basis function over the boundary of
 the domain.  See [Linear Form Integrators](lininteg.md) for more
@@ -356,14 +356,14 @@ information.
 
 | Class Name                          | Operator                                            | Continuous Op.                             | Continuous Boundary Op.                             |
 |-------------------------------------|-----------------------------------------------------|--------------------------------------------|-----------------------------------------------------|
-| CurlCurlIntegrator                  | $(\lambda\curl\vec\{u},\curl\vec\{v})$              | $\curl(\lambda\curl\vec\{u})$              | $\lambda\,\hat\{n}\times\curl\vec\{u}$              |
-| MixedCurlCurlIntegrator             | $(\lambda\curl\vec\{u},\curl\vec\{v})$              | $\curl(\lambda\curl\vec\{u})$              | $\lambda\,\hat\{n}\times\curl\vec\{u}$              |
-| MixedCrossCurlCurlIntegrator        | $(\vec\{\lambda}\cross\curl\vec\{u},\curl\vec\{v})$ | $\curl(\vec\{\lambda}\cross\curl\vec\{u})$ | $\hat\{n}\times(\vec\{\lambda}\cross\curl\vec\{u})$ |
-| MixedCrossGradCurlIntegrator        | $(\vec\{\lambda}\cross\grad u,\curl\vec\{v})$       | $\curl(\vec\{\lambda}\cross\grad u)$       | $\hat\{n}\times(\vec\{\lambda}\cross\grad u)$       |
-| MixedVectorWeakCurlIntegrator       | $(\lambda\vec\{u},\curl\vec\{v})$                   | $\curl(\lambda\vec\{u})$                   | $\lambda\,\hat\{n}\times\vec\{u}$                   |
-| MixedScalarWeakCurlIntegrator       | $(\lambda u,\curl\vec\{v})$                         | $\curl(\lambda\,u\,\hat\{z})\;$            | $\lambda\,u\,\hat\{n}\times\hat\{z}$                |
-| MixedWeakCurlCrossIntegrator        | $(\vec\{\lambda}\cross\vec\{u},\curl\vec\{v})$      | $\curl(\vec\{\lambda}\cross\vec\{u})$      | $\hat\{n}\times(\vec\{\lambda}\cross\vec\{u})$      |
-| MixedScalarWeakCurlCrossIntegrator  | $(\vec\{\lambda}\cross\vec\{u},\curl\vec\{v})$      | $\curl(\vec\{\lambda}\cross\vec\{u})$      | $\hat\{n}\times(\vec\{\lambda}\cross\vec\{u})$      |
+| CurlCurlIntegrator                  | $(\lambda\curl\vec\{u},\curl\vec\{v})$              | $\curl(\lambda\curl\vec\{u})$              | $-\lambda\,\hat\{n}\times\curl\vec\{u}$              |
+| MixedCurlCurlIntegrator             | $(\lambda\curl\vec\{u},\curl\vec\{v})$              | $\curl(\lambda\curl\vec\{u})$              | $-\lambda\,\hat\{n}\times\curl\vec\{u}$              |
+| MixedCrossCurlCurlIntegrator        | $(\vec\{\lambda}\cross\curl\vec\{u},\curl\vec\{v})$ | $\curl(\vec\{\lambda}\cross\curl\vec\{u})$ | $-\hat\{n}\times(\vec\{\lambda}\cross\curl\vec\{u})$ |
+| MixedCrossGradCurlIntegrator        | $(\vec\{\lambda}\cross\grad u,\curl\vec\{v})$       | $\curl(\vec\{\lambda}\cross\grad u)$       | $-\hat\{n}\times(\vec\{\lambda}\cross\grad u)$       |
+| MixedVectorWeakCurlIntegrator       | $(\lambda\vec\{u},\curl\vec\{v})$                   | $\curl(\lambda\vec\{u})$                   | $-\lambda\,\hat\{n}\times\vec\{u}$                   |
+| MixedScalarWeakCurlIntegrator       | $(\lambda u,\curl\vec\{v})$                         | $\curl(\lambda\,u\,\hat\{z})\;$            | $-\lambda\,u\,\hat\{n}\times\hat\{z}$                |
+| MixedWeakCurlCrossIntegrator        | $(\vec\{\lambda}\cross\vec\{u},\curl\vec\{v})$      | $\curl(\vec\{\lambda}\cross\vec\{u})$      | $-\hat\{n}\times(\vec\{\lambda}\cross\vec\{u})$      |
+| MixedScalarWeakCurlCrossIntegrator  | $(\vec\{\lambda}\cross\vec\{u},\curl\vec\{v})$      | $\curl(\vec\{\lambda}\cross\vec\{u})$      | $-\hat\{n}\times(\vec\{\lambda}\cross\vec\{u})$      |
 
 The following weak operators require the range (or test) space to be
 H(Div) i.e. a vector basis function with a divergence operator.  The

--- a/src/bilininteg.md
+++ b/src/bilininteg.md
@@ -309,7 +309,8 @@ situations rather than needing to reimplement their functionality.
 Weak operators use integration by parts to move a spatial derivative
 onto the test function.  This results in an implied boundary integral
 that is often assumed to be zero but can be used to apply a
-non-homogeneous Neumann boundary condition.
+non-homogeneous Neumann boundary condition given a known function
+$u_\mathrm{bc}$ (or $\vec{u}_\mathrm{bc}$ for operators with a vector domain).
 
 ### Operator with Scalar Range
 
@@ -321,22 +322,22 @@ zero.  On the other hand an inhomogeneous Neumann boundary condition
 can be applied by using a linear form boundary integrator to compute
 this boundary term for a known function e.g. when using the
 `DiffusionIntegrator` one could provide a known function for
-$\lambda\,\grad u$ to the `BoundaryNormalLFIntegrator` which would
+$\lambda\,\grad u_\mathrm{bc}$ to the `BoundaryNormalLFIntegrator` which would
 then integrate the normal component of this function over the boundary
 of the domain.  See [Linear Form Integrators](lininteg.md) for more
 information.
 
 | Class Name                          | Operator                                      | Continuous Op.                             | Continuous Boundary Op.                            |
 |-------------------------------------|-----------------------------------------------|--------------------------------------------|----------------------------------------------------|
-| DiffusionIntegrator                 | $(\lambda\grad u, \grad v)$                   | $-\div(\lambda\grad u)$                    | $\lambda\,\hat\{n}\cdot\grad u$                    |
-| MixedGradGradIntegrator             | $(\lambda\grad u, \grad v)$                   | $-\div(\lambda\grad u)$                    | $\lambda\,\hat\{n}\cdot\grad u$                    |
-| MixedCrossGradGradIntegrator        | $(\vec\{\lambda}\cross\grad u,\grad v)$       | $-\div(\vec\{\lambda}\cross\grad u)$       | $\hat\{n}\cdot(\vec\{\lambda}\times\grad u)$       |
-| MixedScalarWeakDivergenceIntegrator | $(-\vec\{\lambda}u,\grad v)$                  | $\div(\vec\{\lambda}u)$                    | $-\hat\{n}\cdot\vec\{\lambda}\,u$                  |
-| MixedScalarWeakDerivativeIntegrator | $(-\lambda u, \ddx\{v})$                      | $\ddx\{}(\lambda u)\;$                     | $-\hat\{n}\cdot\hat\{x}\,\lambda\,u$               |
-| MixedVectorWeakDivergenceIntegrator | $(-\lambda\vec\{u},\grad v)$                  | $\div(\lambda\vec\{u})$                    | $-\hat\{n}\cdot(\lambda\,\vec\{u})$                |
-| MixedWeakDivCrossIntegrator         | $(-\vec\{\lambda}\cross\vec\{u},\grad v)$     | $\div(\vec\{\lambda}\cross\vec\{u})$       | $-\hat\{n}\cdot(\vec\{\lambda}\times\vec\{u})$     |
-| MixedCrossCurlGradIntegrator        | $(\vec\{\lambda}\cross\curl\vec\{u},\grad v)$ | $-\div(\vec\{\lambda}\cross\curl\vec\{u})$ | $\hat\{n}\cdot(\vec\{\lambda}\cross\curl\vec\{u})$ |
-| MixedDivGradIntegrator              | $(\vec\{\lambda}\div\vec\{u}, \grad v)$       | $-\div(\vec\{\lambda}\div\vec\{u})$        | $\hat\{n}\cdot(\vec\{\lambda}\div\vec\{u})$        |
+| DiffusionIntegrator                 | $(\lambda\grad u, \grad v)$                   | $-\div(\lambda\grad u)$                    | $\lambda\,\hat\{n}\cdot\grad u_\mathrm\{bc}$                    |
+| MixedGradGradIntegrator             | $(\lambda\grad u, \grad v)$                   | $-\div(\lambda\grad u)$                    | $\lambda\,\hat\{n}\cdot\grad u_\mathrm\{bc}$                    |
+| MixedCrossGradGradIntegrator        | $(\vec\{\lambda}\cross\grad u,\grad v)$       | $-\div(\vec\{\lambda}\cross\grad u)$       | $\hat\{n}\cdot(\vec\{\lambda}\times\grad u_\mathrm\{bc})$       |
+| MixedScalarWeakDivergenceIntegrator | $(-\vec\{\lambda}u,\grad v)$                  | $\div(\vec\{\lambda}u)$                    | $-\hat\{n}\cdot\vec\{\lambda}\,u_\mathrm\{bc}$                  |
+| MixedScalarWeakDerivativeIntegrator | $(-\lambda u, \ddx\{v})$                      | $\ddx\{}(\lambda u)\;$                     | $-\hat\{n}\cdot\hat\{x}\,\lambda\,u_\mathrm\{bc}$               |
+| MixedVectorWeakDivergenceIntegrator | $(-\lambda\vec\{u},\grad v)$                  | $\div(\lambda\vec\{u})$                    | $-\hat\{n}\cdot(\lambda\,\vec\{u}_\mathrm\{bc})$                |
+| MixedWeakDivCrossIntegrator         | $(-\vec\{\lambda}\cross\vec\{u},\grad v)$     | $\div(\vec\{\lambda}\cross\vec\{u})$       | $-\hat\{n}\cdot(\vec\{\lambda}\times\vec\{u}_\mathrm\{bc})$     |
+| MixedCrossCurlGradIntegrator        | $(\vec\{\lambda}\cross\curl\vec\{u},\grad v)$ | $-\div(\vec\{\lambda}\cross\curl\vec\{u})$ | $\hat\{n}\cdot(\vec\{\lambda}\cross\curl\vec\{u}_\mathrm\{bc})$ |
+| MixedDivGradIntegrator              | $(\vec\{\lambda}\div\vec\{u}, \grad v)$       | $-\div(\vec\{\lambda}\div\vec\{u})$        | $\hat\{n}\cdot(\vec\{\lambda}\div\vec\{u}_\mathrm\{bc})$        |
 
 ### Operator with Vector Range
 
@@ -348,7 +349,7 @@ equal to zero.  On the other hand a non-homogeneous Neumann boundary
 condition can be applied by using a linear form boundary integrator to
 compute this boundary term for a known function e.g. when using the
 `CurlCurlIntegrator` one could provide a known function for
-$-\lambda\,\curl\vec\{u}$ to the `VectorFEBoundaryTangentLFIntegrator`
+$-\lambda\,\curl\vec\{u}_\mathrm{bc}$ to the `VectorFEBoundaryTangentLFIntegrator`
 which would then integrate the product of the tangential portion of
 this function with that of the ND basis function over the boundary of
 the domain.  See [Linear Form Integrators](lininteg.md) for more
@@ -356,14 +357,14 @@ information.
 
 | Class Name                          | Operator                                            | Continuous Op.                             | Continuous Boundary Op.                             |
 |-------------------------------------|-----------------------------------------------------|--------------------------------------------|-----------------------------------------------------|
-| CurlCurlIntegrator                  | $(\lambda\curl\vec\{u},\curl\vec\{v})$              | $\curl(\lambda\curl\vec\{u})$              | $-\lambda\,\hat\{n}\times\curl\vec\{u}$              |
-| MixedCurlCurlIntegrator             | $(\lambda\curl\vec\{u},\curl\vec\{v})$              | $\curl(\lambda\curl\vec\{u})$              | $-\lambda\,\hat\{n}\times\curl\vec\{u}$              |
-| MixedCrossCurlCurlIntegrator        | $(\vec\{\lambda}\cross\curl\vec\{u},\curl\vec\{v})$ | $\curl(\vec\{\lambda}\cross\curl\vec\{u})$ | $-\hat\{n}\times(\vec\{\lambda}\cross\curl\vec\{u})$ |
-| MixedCrossGradCurlIntegrator        | $(\vec\{\lambda}\cross\grad u,\curl\vec\{v})$       | $\curl(\vec\{\lambda}\cross\grad u)$       | $-\hat\{n}\times(\vec\{\lambda}\cross\grad u)$       |
-| MixedVectorWeakCurlIntegrator       | $(\lambda\vec\{u},\curl\vec\{v})$                   | $\curl(\lambda\vec\{u})$                   | $-\lambda\,\hat\{n}\times\vec\{u}$                   |
-| MixedScalarWeakCurlIntegrator       | $(\lambda u,\curl\vec\{v})$                         | $\curl(\lambda\,u\,\hat\{z})\;$            | $-\lambda\,u\,\hat\{n}\times\hat\{z}$                |
-| MixedWeakCurlCrossIntegrator        | $(\vec\{\lambda}\cross\vec\{u},\curl\vec\{v})$      | $\curl(\vec\{\lambda}\cross\vec\{u})$      | $-\hat\{n}\times(\vec\{\lambda}\cross\vec\{u})$      |
-| MixedScalarWeakCurlCrossIntegrator  | $(\vec\{\lambda}\cross\vec\{u},\curl\vec\{v})$      | $\curl(\vec\{\lambda}\cross\vec\{u})$      | $-\hat\{n}\times(\vec\{\lambda}\cross\vec\{u})$      |
+| CurlCurlIntegrator                  | $(\lambda\curl\vec\{u},\curl\vec\{v})$              | $\curl(\lambda\curl\vec\{u})$              | $-\lambda\,\hat\{n}\times\curl\vec\{u}_\mathrm\{bc}$              |
+| MixedCurlCurlIntegrator             | $(\lambda\curl\vec\{u},\curl\vec\{v})$              | $\curl(\lambda\curl\vec\{u})$              | $-\lambda\,\hat\{n}\times\curl\vec\{u}_\mathrm\{bc}$              |
+| MixedCrossCurlCurlIntegrator        | $(\vec\{\lambda}\cross\curl\vec\{u},\curl\vec\{v})$ | $\curl(\vec\{\lambda}\cross\curl\vec\{u})$ | $-\hat\{n}\times(\vec\{\lambda}\cross\curl\vec\{u}_\mathrm\{bc})$ |
+| MixedCrossGradCurlIntegrator        | $(\vec\{\lambda}\cross\grad u,\curl\vec\{v})$       | $\curl(\vec\{\lambda}\cross\grad u)$       | $-\hat\{n}\times(\vec\{\lambda}\cross\grad u_\mathrm\{bc})$       |
+| MixedVectorWeakCurlIntegrator       | $(\lambda\vec\{u},\curl\vec\{v})$                   | $\curl(\lambda\vec\{u})$                   | $-\lambda\,\hat\{n}\times\vec\{u}_\mathrm\{bc}$                   |
+| MixedScalarWeakCurlIntegrator       | $(\lambda u,\curl\vec\{v})$                         | $\curl(\lambda\,u\,\hat\{z})\;$            | $-\lambda\,u_\mathrm\{bc}\,\hat\{n}\times\hat\{z}$                |
+| MixedWeakCurlCrossIntegrator        | $(\vec\{\lambda}\cross\vec\{u},\curl\vec\{v})$      | $\curl(\vec\{\lambda}\cross\vec\{u})$      | $-\hat\{n}\times(\vec\{\lambda}\cross\vec\{u}_\mathrm\{bc})$      |
+| MixedScalarWeakCurlCrossIntegrator  | $(\vec\{\lambda}\cross\vec\{u},\curl\vec\{v})$      | $\curl(\vec\{\lambda}\cross\vec\{u})$      | $-\hat\{n}\times(\vec\{\lambda}\cross\vec\{u}_\mathrm\{bc})$      |
 
 The following weak operators require the range (or test) space to be
 H(Div) i.e. a vector basis function with a divergence operator.  The
@@ -373,7 +374,7 @@ equal to zero.  On the other hand a non-homogeneous Neumann boundary
 condition can be applied by using a linear form boundary integrator to
 compute this boundary term for a known function e.g. when using the
 `DivDivIntegrator` one could provide a known function for
-$\lambda\,\div\vec\{u}$ to the `VectorFEBoundaryFluxLFIntegrator`
+$\lambda\,\div\vec\{u}_\mathrm{bc}$ to the `VectorFEBoundaryFluxLFIntegrator`
 which would then integrate the product of this function with the
 normal component of the RT basis function over the boundary of the
 domain.  See [Linear Form Integrators](lininteg.md) for more
@@ -381,10 +382,10 @@ information.
 
 | Class Name                          | Operator                                            | Continuous Op.                       | Continuous Boundary Op.                  |
 |-------------------------------------|-----------------------------------------------------|--------------------------------------|------------------------------------------|
-| DivDivIntegrator                    | $(\lambda\div\vec\{u},\div\vec\{v})$                | $-\grad(\lambda\div\vec\{u})$        | $\lambda\div\vec\{u}\,\hat\{n}$          |
-| MixedGradDivIntegrator              | $(\vec\{\lambda}\cdot\grad u, \div\vec\{v})$        | $-\grad(\vec\{\lambda}\cdot\grad u)$ | $\vec\{\lambda}\cdot\grad u\,\hat\{n}$   |
-| MixedScalarWeakGradientIntegrator   | $(-\lambda u, \div\vec\{v})$                        | $\grad(\lambda u)$                   | $-\lambda u\,\hat\{n}$                   |
-| MixedWeakGradDotIntegrator          | $(-\vec\{\lambda}\cdot\vec\{u},\div\vec\{v})$       | $\grad(\vec\{\lambda}\cdot\vec\{u})$ | $-\vec\{\lambda}\cdot\vec\{u}\,\hat\{n}$ |
+| DivDivIntegrator                    | $(\lambda\div\vec\{u},\div\vec\{v})$                | $-\grad(\lambda\div\vec\{u})$        | $\lambda\div\vec\{u}_\mathrm\{bc}\,\hat\{n}$          |
+| MixedGradDivIntegrator              | $(\vec\{\lambda}\cdot\grad u, \div\vec\{v})$        | $-\grad(\vec\{\lambda}\cdot\grad u)$ | $\vec\{\lambda}\cdot\grad u_\mathrm\{bc}\,\hat\{n}$   |
+| MixedScalarWeakGradientIntegrator   | $(-\lambda u, \div\vec\{v})$                        | $\grad(\lambda u)$                   | $-\lambda u_\mathrm\{bc}\,\hat\{n}$                   |
+| MixedWeakGradDotIntegrator          | $(-\vec\{\lambda}\cdot\vec\{u},\div\vec\{v})$       | $\grad(\vec\{\lambda}\cdot\vec\{u})$ | $-\vec\{\lambda}\cdot\vec\{u}_\mathrm\{bc}\,\hat\{n}$ |
 
 ## Device support
 

--- a/src/examples.md
+++ b/src/examples.md
@@ -2248,7 +2248,7 @@ A heat equation is described on the outer box domain
 \begin{align}
    \frac{\partial T}{\partial t} &= \kappa \Delta T &&\mbox{in outer box}\\\\
    T &= T_{wall} &&\mbox{on outside wall}\\\\
-   \nabla T \cdot \vec{n} &= 0 &&\mbox{on inside (cylinder) wall}
+   \nabla T \cdot \hat{n} &= 0 &&\mbox{on inside (cylinder) wall}
 \end{align}
 
 with temperature $T$ and coefficient $\kappa$ (non-physical in this example).
@@ -2257,7 +2257,7 @@ A convection-diffusion equation is described inside the cylinder domain
 \begin{align}
    \frac{\partial T}{\partial t} &= \kappa \Delta T - \alpha \nabla \cdot (\vec{b} T) & &\mbox{in inner cylinder}\\\\
    T &= T_{wall} & &\mbox{on cylinder wall}\\\\
-   \nabla T \cdot \vec{n} &= 0 & &\mbox{else}
+   \nabla T \cdot \hat{n} &= 0 & &\mbox{else}
 \end{align}
 
 with temperature $T$, coefficients $\kappa$, $\alpha$ and prescribed velocity profile $\vec{b}$, and

--- a/src/lininteg.md
+++ b/src/lininteg.md
@@ -93,7 +93,7 @@ and are denoted with $\left<\cdot,\cdot\right>$.
 |------------------------|-------|------------------------------------|------------------| ---------- |
 | BoundaryLFIntegrator    | H1, L2 | $(f, v)$ | $f$ | 1D, 2D, 3D |
 | BoundaryNormalLFIntegrator  | H1, L2 | $(\vec\{f} \cdot \hat\{n}, v)$ | $\vec\{f} \cdot \hat\{n}$ | 1D, 2D, 3D |
-| BoundaryTangentialLFIntegrator | H1, L2 | $(\vec\{f} \cdot \vec\{\tau}, v)$ | $\vec\{f} \cdot \vec\{\tau}$ | 2D |
+| BoundaryTangentialLFIntegrator | H1, L2 | $(\vec\{f} \cdot \hat\{\tau}, v)$ | $\vec\{f} \cdot \hat\{\tau}$ | 2D |
 | BoundaryFlowIntegrator | H1, L2 | $\frac\{\alpha}\{2}\, \left< (\vec\{u} \cdot \hat\{n})\, f, v \right> - \beta\, \left<\mid \vec\{u} \cdot \hat\{n} \mid f, v \right>$ | $\frac\{\alpha}\{2} (\vec\{u} \cdot \hat\{n})\, f - \beta \mid \vec\{u} \cdot \hat\{n} \mid f$ | 1D, 2D, 3D |
 
 ### Face Integrators

--- a/src/lininteg.md
+++ b/src/lininteg.md
@@ -92,15 +92,15 @@ and are denoted with $\left<\cdot,\cdot\right>$.
 | Class Name             | Space  | Operator                           | Continuous Op.   | Dimension  |
 |------------------------|-------|------------------------------------|------------------| ---------- |
 | BoundaryLFIntegrator    | H1, L2 | $(f, v)$ | $f$ | 1D, 2D, 3D |
-| BoundaryNormalLFIntegrator  | H1, L2 | $(\vec\{f} \cdot \vec\{n}, v)$ | $\vec\{f} \cdot \vec\{n}$ | 1D, 2D, 3D |
+| BoundaryNormalLFIntegrator  | H1, L2 | $(\vec\{f} \cdot \hat\{n}, v)$ | $\vec\{f} \cdot \hat\{n}$ | 1D, 2D, 3D |
 | BoundaryTangentialLFIntegrator | H1, L2 | $(\vec\{f} \cdot \vec\{\tau}, v)$ | $\vec\{f} \cdot \vec\{\tau}$ | 2D |
-| BoundaryFlowIntegrator | H1, L2 | $\frac\{\alpha}\{2}\, \left< (\vec\{u} \cdot \vec\{n})\, f, v \right> - \beta\, \left<\mid \vec\{u} \cdot \vec\{n} \mid f, v \right>$ | $\frac\{\alpha}\{2} (\vec\{u} \cdot \vec\{n})\, f - \beta \mid \vec\{u} \cdot \vec\{n} \mid f$ | 1D, 2D, 3D |
+| BoundaryFlowIntegrator | H1, L2 | $\frac\{\alpha}\{2}\, \left< (\vec\{u} \cdot \hat\{n})\, f, v \right> - \beta\, \left<\mid \vec\{u} \cdot \hat\{n} \mid f, v \right>$ | $\frac\{\alpha}\{2} (\vec\{u} \cdot \hat\{n})\, f - \beta \mid \vec\{u} \cdot \hat\{n} \mid f$ | 1D, 2D, 3D |
 
 ### Face Integrators
 
 | Class Name             | Space  | Operator                           | Continuous Op.   | Dimension  |
 |------------------------|-------|------------------------------------|------------------| ---------- |
-| DGDirichletLFIntegrator | L2 | $\sigma \left< u_D, Q \nabla v \cdot \vec\{n} \right> + \kappa \left< \\\{h^\{-1} Q\\\} u_D, v \right>$ | DG essential BCs for $u_D$ | 1D, 2D, 3D
+| DGDirichletLFIntegrator | L2 | $\sigma \left< u_D, Q \nabla v \cdot \hat\{n} \right> + \kappa \left< \\\{h^\{-1} Q\\\} u_D, v \right>$ | DG essential BCs for $u_D$ | 1D, 2D, 3D
 
 
 ## Vector Field Operators
@@ -119,15 +119,15 @@ and are denoted with $\left<\cdot,\cdot\right>$.
 | Class Name             | Space  | Operator                           | Continuous Op.   | Dimension  |
 |------------------------|--------|------------------------------------|------------------| ---------- |
 | VectorBoundaryLFIntegrator    | H1, L2 | $( \vec\{f}, \vec\{v} )$ | $\vec\{f}$ | 1D, 2D, 3D |
-| VectorBoundaryFluxLFIntegrator  | H1, L2 | $( f, \vec\{v} \cdot \vec\{n} )$ | $f \vec\{n}$ | 1D, 2D, 3D |
-| VectorFEBoundaryFluxLFIntegrator  | RT | $( f, \vec\{v} \cdot \vec\{n} )$ | $f \vec\{n}$ | 2D, 3D |
-| VectorFEBoundaryTangentLFIntegrator  | ND | $( \vec\{n} \times \vec\{f}, \vec\{v} )$ | $\vec\{n} \times \vec\{f}$ | 2D, 3D |
+| VectorBoundaryFluxLFIntegrator  | H1, L2 | $( f, \vec\{v} \cdot \hat\{n} )$ | $f \hat\{n}$ | 1D, 2D, 3D |
+| VectorFEBoundaryFluxLFIntegrator  | RT | $( f, \vec\{v} \cdot \hat\{n} )$ | $f \hat\{n}$ | 2D, 3D |
+| VectorFEBoundaryTangentLFIntegrator  | ND | $( \hat\{n} \times \vec\{f}, \vec\{v} )$ | $\hat\{n} \times \vec\{f}$ | 2D, 3D |
 
 ### Face Integrators
 
 | Class Name             | Space  | Operator                           | Continuous Op.   | Dimension  |
 |------------------------|-------|------------------------------------|------------------| ---------- |
-| DGElasticityDirichletLFIntegrator | L2 | $\alpha\left<\vec\{u_D}, \left(\lambda \left(\div \vec\{v}\right) I + \mu \left(\nabla\vec\{v} + \nabla\vec\{v}^T\right)\right) \cdot \vec\{n}\right> \\\\ + \kappa\left< h^\{-1} (\lambda + 2 \mu) \vec\{u_D}, \vec\{v} \right>$ | DG essential BCs for $\vec\{u_D}$ | 1D, 2D, 3D
+| DGElasticityDirichletLFIntegrator | L2 | $\alpha\left<\vec\{u_D}, \left(\lambda \left(\div \vec\{v}\right) I + \mu \left(\nabla\vec\{v} + \nabla\vec\{v}^T\right)\right) \cdot \hat\{n}\right> \\\\ + \kappa\left< h^\{-1} (\lambda + 2 \mu) \vec\{u_D}, \vec\{v} \right>$ | DG essential BCs for $\vec\{u_D}$ | 1D, 2D, 3D
 
 <script type="text/x-mathjax-config">MathJax.Hub.Config({TeX: {equationNumbers: {autoNumber: "all"}}, tex2jax: {inlineMath: [['$','$']]}});</script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS_HTML"></script>

--- a/src/lininteg.md
+++ b/src/lininteg.md
@@ -119,8 +119,8 @@ and are denoted with $\left<\cdot,\cdot\right>$.
 | Class Name             | Space  | Operator                           | Continuous Op.   | Dimension  |
 |------------------------|--------|------------------------------------|------------------| ---------- |
 | VectorBoundaryLFIntegrator    | H1, L2 | $( \vec\{f}, \vec\{v} )$ | $\vec\{f}$ | 1D, 2D, 3D |
-| VectorBoundaryFluxLFIntegrator  | H1, L2 | $( f, \vec\{v} \cdot \vec\{n} )$ | $\vec\{f}$ | 1D, 2D, 3D |
-| VectorFEBoundaryFluxLFIntegrator  | RT | $( f, \vec\{v} \cdot \vec\{n} )$ | $\vec\{f}$ | 2D, 3D |
+| VectorBoundaryFluxLFIntegrator  | H1, L2 | $( f, \vec\{v} \cdot \vec\{n} )$ | $f \vec\{n}$ | 1D, 2D, 3D |
+| VectorFEBoundaryFluxLFIntegrator  | RT | $( f, \vec\{v} \cdot \vec\{n} )$ | $f \vec\{n}$ | 2D, 3D |
 | VectorFEBoundaryTangentLFIntegrator  | ND | $( \vec\{n} \times \vec\{f}, \vec\{v} )$ | $\vec\{n} \times \vec\{f}$ | 2D, 3D |
 
 ### Face Integrators

--- a/src/lininteg.md
+++ b/src/lininteg.md
@@ -46,7 +46,7 @@ more exotic, forms are possible:
 + Integrals involving mix of Scalar and Vector rhs $\,\vec{f}$ and basis functions: $\int_\Omega f\,\vec\{\lambda}\cdot\vec\{v}$ and $\int_\Omega v\,\vec\{\lambda}\cdot\vec\{f}$
 
 The `LinearFormIntegrator` classes allow MFEM to produce a wide variety of local
-element matrices without modifying the `LinearForm` class. Many of the possible
+element vectors without modifying the `LinearForm` class. Many of the possible
 operators are collected below into tables that briefly describe their action and
 requirements.
 


### PR DESCRIPTION
Hi Tzanio,

I think commit 41878ad won't be controversial as it simple aligns the notation with what you already wrote for the H(div) continuous boundary operators in the Bilinear Form Integrators page.

~Commit 9680418 might be. But, unless you are compensating for the sign within `VectorFEBoundaryTangentLFIntegrator`, which doesn't sound like something you would do(?), I think we do need to flip the sign in the docs?~
EDIT: We aren't compensating for the sign within `VectorFEBoundaryTangentLFIntegrator` (which I think is a good thing 🙂), so we definitely need the sign flip in the docs. I think the confusion might've arisen because it looks like the units tests we have for `VectorFEBoundaryTangentLFIntegrator` are all projections, where the domain and boundary operators appear both on the right-hand side with the same sign. The docs cover the more general case though, i.e. solving for $u$ or $\vec{u}$, where that isn't the case.

Cheers,
-N