### PR TITLE
Minor improvements to Bilinear Form Integrators page

### DIFF
--- a/src/bilininteg.md
+++ b/src/bilininteg.md
@@ -92,7 +92,7 @@ Note that any operators involving a derivative of the range function
 $v$ or $\vec\{v}$ are computed using integration by parts.  This leads
 to a boundary integral which can be used to apply Neumann boundary
 conditions.  Some of these operators are listed along with their
-boundary terms in section [Weak Operators](#weak-operators-and-their-boundary-integrals).
+boundary terms in section [Weak Operators and Their Boundary Integrals](#weak-operators-and-their-boundary-integrals).
 
 ## Scalar Field Operators
 
@@ -102,7 +102,7 @@ require a gradient operator should be used with H1.
 
 ### Square Operators
 
-These integrators are designed to be used with the BilinearForm object
+These integrators are designed to be used with a `BilinearForm` object
 to assemble square linear operators.
 
 | Class Name          | Spaces | Coef.| Operator                    | Continuous Op.          | Dimension  |
@@ -112,7 +112,7 @@ to assemble square linear operators.
 
 ### Mixed Operators
 
-These integrators are designed to be used with the MixedBilinearForm object to assemble square or rectangular linear operators.
+These integrators are designed to be used with a `MixedBilinearForm` object to assemble square or rectangular linear operators.
 
 | Class Name                            | Domain | Range  | Coef.   | Operator                                       | Continuous Op.                       | Dimension  |
 |---------------------------------------|--------|--------|:-------:|------------------------------------------------|--------------------------------------|:----------:|
@@ -150,7 +150,7 @@ functions but others require one or the other.
 
 ### Square Operators
 
-These integrators are designed to be used with the BilinearForm object
+These integrators are designed to be used with a `BilinearForm` object
 to assemble square linear operators.
 
 | Class Name             | Spaces | Coef.   | Operator                               | Continuous Op.                | Dimension  |
@@ -161,7 +161,7 @@ to assemble square linear operators.
 
 ### Mixed Operators
 
-These integrators are designed to be used with the MixedBilinearForm object to assemble square or rectangular linear operators.
+These integrators are designed to be used with a `MixedBilinearForm` object to assemble square or rectangular linear operators.
 
 | Class Name                           | Domain | Range  | Coef.   | Operator                                                 | Continuous Op.                                | Dimension  |
 |--------------------------------------|--------|--------|:-------:|----------------------------------------------------------|-----------------------------------------------|:----------:|
@@ -190,9 +190,9 @@ These integrators are designed to be used with the MixedBilinearForm object to a
 
 | Class Name                       | Domain | Range  | Coef. | Operator                                                               | Dimension | Notes |
 |----------------------------------|--------|--------|-------|------------------------------------------------------------------------|:---------:|-------|
-| VectorFEDivergenceIntegrator     | RT     | H1, L2 |   S   | $(\lambda\div\vec\{u}, v)$                                             | 2D, 3D    | Alternate implementation of MixedScalarDivergenceIntegrator. |
-| VectorFEWeakDivergenceIntegrator | ND     | H1     |   S   | $(-\lambda\vec\{u},\grad v)$                                           | 2D, 3D    | See MixedVectorWeakDivergenceIntegrator for a more general implementation. |
-| VectorFECurlIntegrator           | ND, RT | ND, RT |   S   | $(\lambda\curl\vec\{u},\vec\{v})$ or $(\lambda\vec\{u},\curl\vec\{v})$ | 3D        | If the domain is ND then the Curl operator is returned, if the range is ND then the weak Curl is returned, otherwise a failure is encountered. See MixedVectorCurlIntegrator and MixedVectorWeakCurlIntegrator for more general implementations. |
+| VectorFEDivergenceIntegrator     | RT     | H1, L2 |   S   | $(\lambda\div\vec\{u}, v)$                                             | 2D, 3D    | Alternate implementation of `MixedScalarDivergenceIntegrator`. |
+| VectorFEWeakDivergenceIntegrator | ND     | H1     |   S   | $(-\lambda\vec\{u},\grad v)$                                           | 2D, 3D    | See `MixedVectorWeakDivergenceIntegrator` for a more general implementation. |
+| VectorFECurlIntegrator           | ND, RT | ND, RT |   S   | $(\lambda\curl\vec\{u},\vec\{v})$ or $(\lambda\vec\{u},\curl\vec\{v})$ | 3D        | If the domain is ND then the Curl operator is returned, if the range is ND then the weak Curl is returned, otherwise a failure is encountered. See `MixedVectorCurlIntegrator` and `MixedVectorWeakCurlIntegrator` for more general implementations. |
 
 ## Vector Field Operators
 
@@ -299,9 +299,9 @@ situations rather than needing to reimplement their functionality.
 
 | Class Name          | Description                                                                                                            |
 |---------------------|------------------------------------------------------------------------------------------------------------------------|
-| TransposeIntegrator | Returns the transpose of the local matrix computed by another BilinearFormIntegrator                                   |
-| LumpedIntegrator    | Returns a diagonal local matrix where each entry is the sum of the corresponding row of a local matrix computed by another BilinearFormIntegrator (only implemented for square matrices) |
-| InverseIntegrator   | Returns the inverse of the local matrix computed by another BilinearFormIntegrator which produces a square local matrix |
+| TransposeIntegrator | Returns the transpose of the local matrix computed by another `BilinearFormIntegrator`                                 |
+| LumpedIntegrator    | Returns a diagonal local matrix where each entry is the sum of the corresponding row of a local matrix computed by another `BilinearFormIntegrator` (only implemented for square matrices) |
+| InverseIntegrator   | Returns the inverse of the local matrix computed by another `BilinearFormIntegrator` which produces a square local matrix |
 | SumIntegrator       | Returns the sum of a series of integrators with compatible dimensions (only implemented for square matrices)           |
 
 ## Weak Operators and Their Boundary Integrals


### PR DESCRIPTION
Hi @tzanio,

The initial motivation for this PR was clarifying the requirement for H1 (vs L2) when the gradient operator is required by the integrator. We say L2 spaces have no derivative operator, but (please do correct me if I'm wrong) if mapping by value (but not by integral - why?), we do define a gradient operator. Now, I understand this gradient is local only (i.e. within an element), i.e. it's not defined in the weak sense (i.e. across elements) like in H1, and I expect this is the reason for the H1 requirement. So then I thought that maybe we should add a note explaining this, but it looks like we already say something to this effect: "Many of these operators will work with either H1 or L2 basis functions but some that require a gradient operator should be used with H1.". Is the "should" in this sentence trying to capture what I tried to explain?

While going down the rabbit hole of why we define a gradient when the elements are value- but not integral-mapped, I also came across this [table](https://docs.mfem.org/html/classmfem_1_1FiniteElementCollection.html#a15fcfa553d4949eb08f9926ac74d1e80). Some collections for which the basis type is an option are hard-coded to a specific type, e.g. compare `L2_[DIM]_[ORDER]` and `L2_T[BTYPE]_[DIM]_[ORDER]`: they're both down as (open) Gauss-Legendre. Is this on purpose?

Cheers,
-Nuno