### PR TITLE
Update tutorial instructions

### DIFF
--- a/src/tutorial/docker.md
+++ b/src/tutorial/docker.md
@@ -14,7 +14,7 @@ MFEM and its capabilities in a variety of computing environments: from the cloud
 (like AWS), to HPC clusters, and your own laptop.
 
 There are [CPU](https://github.com/mfem/containers/pkgs/container/containers%2Fdeveloper-cpu)
-and [GPU](https://github.com/mfem/containers/pkgs/container/containers%2Fdeveloper-cuda-sm70)
+and [GPU](https://github.com/mfem/containers/pkgs/container/containers%2Fdeveloper-cuda-sm89)
 variations of the image, we will refer to it generically
 as `mfem/developer` during the tutorial.
 
@@ -40,7 +40,7 @@ Depending on your connection, this may take a while to download and extract (the
 
 To start the container, run:
 
-    docker run --cap-add=SYS_PTRACE -p 3000:3000 -p 8000:8000 -p 8080:8080 ghcr.io/mfem/containers/developer-cpu:latest
+    docker run --cap-add=SYS_PTRACE -p 3000:3000 ghcr.io/mfem/containers/developer-cpu:latest
 
 You can later stop this by pressing <kbd>Ctrl-C</kbd>.
 See the docker [documentation](https://docs.docker.com/engine/reference/commandline/cli/) for more details.
@@ -49,14 +49,16 @@ We provide two variations of our containers that are configured with CPU or CPU
 and GPU capabilities. If you have an NVIDIA supported CUDA GPU you have to
 install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 
-Our CUDA images are built with the `sm_70` compute capability by default. If your GPU is
-an `sm_70` you can use the prebuilt `mfem/developer-cuda-sm70` image with:
+Prebuilt CUDA images are available for the `sm_75` and `sm_89` compute capabilities.
+Use the image that matches your GPU. For example, for an `sm_75` GPU:
 
-    docker pull ghcr.io/mfem/containers/developer-cuda-sm70:latest
+    docker pull ghcr.io/mfem/containers/developer-cuda-sm75:latest
 
 To start the container use
 
-    docker run --gpus all --cap-add=SYS_PTRACE -p 3000:3000 -p 8000:8000 -p 8080:8080 ghcr.io/mfem/containers/developer-cuda-sm70:latest
+    docker run --gpus all --cap-add=SYS_PTRACE -p 3000:3000 ghcr.io/mfem/containers/developer-cuda-sm75:latest
+
+For an `sm_89` GPU, replace `sm75` with `sm89` in these commands.
 
 If you need a different compute capability, you can clone the `mfem/containers`
 [repository](https://github.com/mfem/containers) and build an image e.g., for`sm_80`, with
@@ -73,9 +75,8 @@ This automatically builds all libraries with the correctly supported CUDA comput
 <h3 class="panel-title"><i class="fa fa-info-circle"></i>&nbsp; Note</h3>
 </div>
 <div class="panel-body">
-The forwarding of ports <code>3000</code>, <code>8000</code> and <code>8080</code>
-is needed for
-<a href="../start/#set-up-vs-code">VS Code</a>, <a href="../start/#set-up-glvis">GLVis</a> and the websocket connection between them.
+Forward port <code>3000</code> to access <a href="../start/#set-up-vs-code">VS Code</a>,
+<a href="../start/#set-up-glvis">GLVis</a>, and the GLVis WebSocket bridge through the container's reverse proxy.
 The <code>--cap-add=SYS_PTRACE</code> option is added to resolve MPI warnings.
 </div>
 </div>
@@ -97,7 +98,7 @@ Both of these can take a while, depending on your hardware and network connectio
 To start the virtual machine and the container in it, run:
 
     podman machine start
-    podman run --cap-add=SYS_PTRACE -p 3000:3000 -p 8000:8000 -p 8080:8080 ghcr.io/mfem/containers/developer-cpu:latest
+    podman run --cap-add=SYS_PTRACE -p 3000:3000 ghcr.io/mfem/containers/developer-cpu:latest
 
 You can later stop these by pressing <kbd>Ctrl-C</kbd> and typing `podman machine stop`.
 
@@ -115,23 +116,18 @@ on macOS and follow the Linux <a href="#linux">instructions</a> above.
 
 ### <i class="fa fa-check-square-o"></i>&nbsp; Running the tutorial locally
 
-Once the `mfem/developer` container is running, you can proceed with the
-[<i class="fa fa-play-circle"></i> Getting Started](start.md) page using the
-following `IP`: `127.0.0.1`. You can alternatively use `localhost` for the `IP`.
+Once the `mfem/developer` container is running, open VS Code at:
 
-In particular, the VS Code and GLVis windows can be accessed at
-[localhost:3000](http://localhost:3000) and
-[localhost:8000/live](http://localhost:8000/live) respectively.
+[localhost:3000/?folder=/home/euler/mfem](http://localhost:3000/?folder=/home/euler/mfem)
+
+and GLVis at:
+
+[localhost:3000/glvis/live/?socket=/glvis-ws](http://localhost:3000/glvis/live/?socket=/glvis-ws).
 
 Furthermore, you can use the above pages from any other devices (tablets,
 phones) that are connected to the same network as the machine running the
 container.
 
-For example you can run an example from the VS Code terminal on your laptop and
-visualize the results on a GLVis window on your phone.
-
-To connect other devices, first run `hostname -s` to get the local host name and then
-use that `{hostname}` for the `IP` in the rest of the tutorial.
 
 ---
 

--- a/src/tutorial/docker.md
+++ b/src/tutorial/docker.md
@@ -129,6 +129,11 @@ Furthermore, you can use the above pages from any other devices (tablets,
 phones) that are connected to the same network as the machine running the
 container.
 
+For example you can run an example from the VS Code terminal on your laptop and
+visualize the results on a GLVis window on your phone.
+
+To connect other devices, first run `hostname -s` to get the local host name and then
+use that `{hostname}` for the `IP` in the rest of the tutorial.
 
 ---
 

--- a/src/tutorial/docker.md
+++ b/src/tutorial/docker.md
@@ -121,6 +121,10 @@ Once the `mfem/developer` container is running, open:
 - VS Code: [localhost:3000/?folder=/home/euler/mfem](http://localhost:3000/?folder=/home/euler/mfem)
 - GLVis: [localhost:3000/glvis/live/?socket=/glvis-ws](http://localhost:3000/glvis/live/?socket=/glvis-ws)
 
+You can now proceed with the
+[<i class="fa fa-play-circle"></i> Getting Started](start.md)
+instructions.
+
 Furthermore, you can use the above pages from any other devices (tablets,
 phones) that are connected to the same network as the machine running the
 container.

--- a/src/tutorial/docker.md
+++ b/src/tutorial/docker.md
@@ -116,13 +116,10 @@ on macOS and follow the Linux <a href="#linux">instructions</a> above.
 
 ### <i class="fa fa-check-square-o"></i>&nbsp; Running the tutorial locally
 
-Once the `mfem/developer` container is running, open VS Code at:
+Once the `mfem/developer` container is running, open:
 
-[localhost:3000/?folder=/home/euler/mfem](http://localhost:3000/?folder=/home/euler/mfem)
-
-and GLVis at:
-
-[localhost:3000/glvis/live/?socket=/glvis-ws](http://localhost:3000/glvis/live/?socket=/glvis-ws).
+- VS Code: [localhost:3000/?folder=/home/euler/mfem](http://localhost:3000/?folder=/home/euler/mfem)
+- GLVis: [localhost:3000/glvis/live/?socket=/glvis-ws](http://localhost:3000/glvis/live/?socket=/glvis-ws)
 
 Furthermore, you can use the above pages from any other devices (tablets,
 phones) that are connected to the same network as the machine running the

--- a/src/tutorial/docker.md
+++ b/src/tutorial/docker.md
@@ -133,7 +133,7 @@ container.
 <h3 class="panel-title"><i class="fa fa-question-circle"></i>&nbsp; Questions?</h3>
 </div>
 <div class="panel-body">
-Ask for help in the tutorial <a href="https://radiuss-llnl.slack.com/archives/C03T2DQCSC8">Slack channel</a>.
+Ask for help in the tutorial <a href="https://mfemworkshop.slack.com/archives/C0B3SM3FT3P">Slack channel</a>.
 </div>
 </div>
 

--- a/src/tutorial/index.md
+++ b/src/tutorial/index.md
@@ -4,8 +4,7 @@
 ![MFEM on AWS](img/mfem-aws.png)
 
 Welcome to the MFEM tutorial, part of the
-[LLNL HPC Software Tutorials Series](https://hpcic.llnl.gov/tutorials/2026-hpc-tutorials)
-in collaboration with [AWS](https://aws.amazon.com/blogs/hpc/call-for-participation-hpc-tutorial-series-from-the-hpcic/).
+[LLNL HPC Software Tutorials Series](https://hpcic.llnl.gov/tutorials/2026-hpc-tutorials).
 
 [MFEM](https://mfem.org/) is a modular parallel C++ library for finite element
 methods developed at [CASC](https://computing.llnl.gov/casc/),

--- a/src/tutorial/start.md
+++ b/src/tutorial/start.md
@@ -32,15 +32,6 @@ Docker container locally, follow the local URLs in the <a href="../docker/#runni
 </div>
 </div>
 
-<div class="panel panel-danger">
-<div class="panel-heading">
-<h3 class="panel-title"><i class="fa fa-warning"></i>&nbsp; Warning</h3>
-</div>
-<div class="panel-body">
-If you use VPN, make sure to <b>turn it off</b> before following the instructions below.
-</div>
-</div>
-
 ---
 
 ### <i class="fa fa-check-square-o"></i>&nbsp; Set up VS Code

--- a/src/tutorial/start.md
+++ b/src/tutorial/start.md
@@ -20,17 +20,15 @@
 <h3 class="panel-title"><i class="fa fa-info-circle"></i>&nbsp; Note</h3>
 </div>
 <div class="panel-body">
-You need an <code>IP</code> address to follow the steps described below.
-<p><p>
-<i class="fa fa-arrow-circle-right"></i>&nbsp; If you are part of the
+If you are part of the
 <a href="https://hpcic.llnl.gov/tutorials/2026-hpc-tutorials">HPC software tutorial series</a>,
-you should have received an email with the AWS instance IP address allocated to you.
-Use that in place of <code>IP</code> in the instructions below.
+use the VS Code and GLVis HTTPS URLs sent by the Slackbot when it starts your development container.
+For example, the Slackbot message includes URLs like
+<code>https://SESSION.mfem.hpcic.training?folder=/home/euler/mfem</code> and
+<code>https://SESSION.mfem.hpcic.training/glvis/live/?socket=/glvis-ws</code>.
 <p><p>
 <i class="fa fa-arrow-circle-right"></i>&nbsp; If you are running a
-Docker container locally, as described in the <a href="../docker/#running-the-tutorial-locally"><span class="mdi mdi-docker"></span> Local Docker Container</a> page, use <code>localhost</code> in place of <code>IP</code> in the instructions below.
-<p><p>
-<i class="fa fa-arrow-circle-right"></i>&nbsp; If you setup your own cloud instance with the Docker container, you should use the cloud instance <code>IP</code> address.
+Docker container locally, follow the local URLs in the <a href="../docker/#running-the-tutorial-locally"><span class="mdi mdi-docker"></span> Local Docker Container</a> page.
 </div>
 </div>
 
@@ -47,7 +45,9 @@ If you use VPN, make sure to <b>turn it off</b> before following the instruction
 
 ### <i class="fa fa-check-square-o"></i>&nbsp; Set up VS Code
 
-- Open a new browser window and load `http://IP:3000`.
+- Open the VS Code URL sent by the Slackbot.
+
+  For a local Docker container, open `http://localhost:3000/?folder=/home/euler/mfem`.
 
 - You should see the Visual Studio Code (VS Code) interface.
 
@@ -55,7 +55,7 @@ If you use VPN, make sure to <b>turn it off</b> before following the instruction
 
 <img class="tight" src="../img/start1.png">
 
-- Click on `open a folder` (under `Recent`), then select `mfem`, then click `OK`.
+- If the VS Code URL includes `?folder=/home/euler/mfem`, the MFEM directory opens automatically. Otherwise, click on `open a folder` (under `Recent`), then select `mfem`, then click `OK`.
 
 - In the left pane, open `examples` and select `ex1.cpp`.
 
@@ -83,25 +83,22 @@ and adjust it similarly to the desktop version.
 
 In this tutorial we use [GLVis](https://glvis.org) for finite element visualization based on MFEM.
 
-- Open a new browser window and load `http://IP:8000/live`.
+- Open the GLVis URL sent by the Slackbot.
+
+  For a local Docker container, open `http://localhost:3000/glvis/live/?socket=/glvis-ws`.
 
 - When you move the mouse to the top of the window you should see the GLVis interface:
 
 <img class="tight" src="../img/start3.png">
-
-- Click on the **Connect to socket** icon &nbsp;<span class="mdi mdi-lan-connect mdi-18px"></span>&nbsp; in
-  the upper left corner, then click `CONNECT`.
 
 <div class="panel panel-info" style="width:92%; margin-left: auto; margin-right: auto;">
 <div class="panel-heading">
 <h3 class="panel-title"><i class="fa fa-info-circle"></i>&nbsp; Note</h3>
 </div>
 <div class="panel-body">
-The <b>Host</b> field in the <b>Connect to socket</b> dialog should match your <code>IP</code>.
+The <code>?socket=/glvis-ws</code> part of the URL automatically connects GLVis to the development container.
 </div>
 </div>
-
-- When the button switches to `DISCONNECT`, click outside of the **Connect to socket** dialog to close it.
 
 - Your environment should now look like:
 

--- a/src/tutorial/start.md
+++ b/src/tutorial/start.md
@@ -82,7 +82,10 @@ In this tutorial we use [GLVis](https://glvis.org) for finite element visualizat
 
 - If the GLVis URL includes <code>?socket=/glvis-ws</code>, it is already connected and you can skip the next step.
 
-- (If needed) Click the **Connect to socket** icon &nbsp;<span class="mdi mdi-lan-connect mdi-18px"></span>&nbsp; in the upper left corner, then enter the current host name followed by <code>/glvis-ws</code> in the <b>Host</b> field, for example <code>SESSION.mfem.hpcic.training/glvis-ws</code> or <code>localhost:3000/glvis-ws</code>, and click `CONNECT`.
+- (If needed) Click the **Connect to socket** icon &nbsp;<span class="mdi mdi-lan-connect mdi-18px"></span>&nbsp; in
+the upper left corner, then enter the current host name followed by <code>/glvis-ws</code> in the <b>Host</b> field,
+for example <code>SESSION.mfem.hpcic.training/glvis-ws</code> or <code>localhost:3000/glvis-ws</code>, and click
+`CONNECT`. When the button switches to `DISCONNECT`, click outside of the **Connect to socket** dialog to close it.
 
 - Your environment should now look like:
 

--- a/src/tutorial/start.md
+++ b/src/tutorial/start.md
@@ -20,10 +20,10 @@
 <h3 class="panel-title"><i class="fa fa-info-circle"></i>&nbsp; Note</h3>
 </div>
 <div class="panel-body">
-If you are part of the
+<i class="fa fa-arrow-circle-right"></i>&nbsp; If you are part of the
 <a href="https://hpcic.llnl.gov/tutorials/2026-hpc-tutorials">HPC software tutorial series</a>,
-use the VS Code and GLVis HTTPS URLs sent by the Slackbot when it starts your development container.
-For example, the Slackbot message includes URLs like
+use the URLs sent by the Slackbot when it starts your development container.
+For example, the Slackbot message includes URLs for VS Code and GLVis like
 <code>https://SESSION.mfem.hpcic.training?folder=/home/euler/mfem</code> and
 <code>https://SESSION.mfem.hpcic.training/glvis/live/?socket=/glvis-ws</code>.
 <p><p>
@@ -36,9 +36,7 @@ Docker container locally, follow the local URLs in the <a href="../docker/#runni
 
 ### <i class="fa fa-check-square-o"></i>&nbsp; Set up VS Code
 
-- Open the VS Code URL sent by the Slackbot.
-
-  For a local Docker container, open `http://localhost:3000/?folder=/home/euler/mfem`.
+- Open the VS Code URL.
 
 - You should see the Visual Studio Code (VS Code) interface.
 
@@ -74,9 +72,7 @@ and adjust it similarly to the desktop version.
 
 In this tutorial we use [GLVis](https://glvis.org) for finite element visualization based on MFEM.
 
-- Open the GLVis URL sent by the Slackbot.
-
-  For a local Docker container, open `http://localhost:3000/glvis/live/?socket=/glvis-ws`.
+- Open the GLVis URL.
 
 - When you move the mouse to the top of the window you should see the GLVis interface:
 

--- a/src/tutorial/start.md
+++ b/src/tutorial/start.md
@@ -36,15 +36,17 @@ Docker container locally, follow the local URLs in the <a href="../docker/#runni
 
 ### <i class="fa fa-check-square-o"></i>&nbsp; Set up VS Code
 
-- Open the VS Code URL.
+- Open the VS Code URL in a new browser window.
 
 - You should see the Visual Studio Code (VS Code) interface.
 
 - Click on `Mark Done` to continue.
 
+- If the VS Code URL includes `?folder=/home/euler/mfem`, the MFEM directory opens automatically and you can skip the next step.
+
 <img class="tight" src="../img/start1.png">
 
-- If the VS Code URL includes `?folder=/home/euler/mfem`, the MFEM directory opens automatically. Otherwise, click on `open a folder` (under `Recent`), then select `mfem`, then click `OK`.
+- (If needed) Click on `open a folder` (under `Recent`), then select `mfem`, then click `OK`.
 
 - In the left pane, open `examples` and select `ex1.cpp`.
 
@@ -72,20 +74,15 @@ and adjust it similarly to the desktop version.
 
 In this tutorial we use [GLVis](https://glvis.org) for finite element visualization based on MFEM.
 
-- Open the GLVis URL.
+- Open the GLVis URL in a new browser window.
 
 - When you move the mouse to the top of the window you should see the GLVis interface:
 
 <img class="tight" src="../img/start3.png">
 
-<div class="panel panel-info" style="width:92%; margin-left: auto; margin-right: auto;">
-<div class="panel-heading">
-<h3 class="panel-title"><i class="fa fa-info-circle"></i>&nbsp; Note</h3>
-</div>
-<div class="panel-body">
-The <code>?socket=/glvis-ws</code> part of the URL automatically connects GLVis to the development container.
-</div>
-</div>
+- If the GLVis URL includes <code>?socket=/glvis-ws</code>, it is already connected and you can skip the next step.
+
+- (If needed) Click the **Connect to socket** icon &nbsp;<span class="mdi mdi-lan-connect mdi-18px"></span>&nbsp; in the upper left corner, then enter the current host name followed by <code>/glvis-ws</code> in the <b>Host</b> field, for example <code>SESSION.mfem.hpcic.training/glvis-ws</code> or <code>localhost:3000/glvis-ws</code>, and click `CONNECT`.
 
 - Your environment should now look like:
 


### PR DESCRIPTION
Update tutorial instructions for newer version:

## URLs for VSCode and GLVis: 
- The AWS set up now uses HTTPS URLs so no longer of the form `IP:3000`
- the developer docker image uses nginx to put both VS Code and GLVis at port 3000
- VS Code: if users click on the URL with `?folder` param they don't need to manually choose a folder in VS Code
- GLVis: if users click on the URL with `?socket` param they don't need to manually connect in GLVis
- VPN not an issue with HTTPS

## Other
- AWS not a sponsor this year
- ~~Refer to mfem workshop slack instead of RADIUSS slack~~
- Update SM versions in docker references
- Drop references to own cloud instance with the Docker container as that seems a bit niche to give instructions for in my opinion
